### PR TITLE
Forgot Password for User & Admin

### DIFF
--- a/src/app/[store_slug]/forgot-password/page.tsx
+++ b/src/app/[store_slug]/forgot-password/page.tsx
@@ -1,0 +1,24 @@
+// app/[store_slug]/forgot-password/page.tsx
+"use client";
+
+import { Suspense } from "react";
+import { ForgotPasswordForm } from "@/app/components/auth/ForgotPasswordForm";
+import { SheiLoader } from "@/app/components/ui/SheiLoader/loader";
+
+export default function StoreForgotPasswordPage() {
+  return (
+    <div className="min-h-screen bg-background flex items-center justify-center p-4">
+      <div className="w-full max-w-md">
+        <Suspense
+          fallback={
+            <div className="flex justify-center">
+              <SheiLoader size="md" loadingText="Loading..." />
+            </div>
+          }
+        >
+          <ForgotPasswordForm type="user" />
+        </Suspense>
+      </div>
+    </div>
+  );
+}

--- a/src/app/[store_slug]/login/LoginForm.tsx
+++ b/src/app/[store_slug]/login/LoginForm.tsx
@@ -411,6 +411,7 @@ export function LoginForm() {
           onLogin={handleLogin}
           onBack={customerData?.phone && (!customerData.email || customerData.email.trim() === "") ? backToEmailInput : resetToInitial}
           isLoggingIn={isProcessing}
+          storeSlug={storeSlug}
         />
       )}
 

--- a/src/app/[store_slug]/signup/SignupForm.tsx
+++ b/src/app/[store_slug]/signup/SignupForm.tsx
@@ -187,10 +187,14 @@ export function SignupForm() {
         throw new Error("Store not found");
       }
 
+      // Read phone from URL params (LoginForm redirects here with ?phone=xxx)
+      const phoneFromUrl = searchParams.get("phone") || formData.phone || "";
+
       // Create customer record
       const customer = await signupQueries.createCustomer(
-        data.email, 
-        authData.user?.id || loginData?.user?.id
+        data.email,
+        authData.user?.id || loginData?.user?.id,
+        phoneFromUrl
       );
 
       // Create store-customer link

--- a/src/app/[store_slug]/update-password/page.tsx
+++ b/src/app/[store_slug]/update-password/page.tsx
@@ -1,0 +1,24 @@
+// app/[store_slug]/update-password/page.tsx
+"use client";
+
+import { Suspense } from "react";
+import { UpdatePasswordForm } from "@/app/components/auth/UpdatePasswordForm";
+import { SheiLoader } from "@/app/components/ui/SheiLoader/loader";
+
+export default function StoreUpdatePasswordPage() {
+  return (
+    <div className="min-h-screen bg-background flex items-center justify-center p-4">
+      <div className="w-full max-w-md">
+        <Suspense
+          fallback={
+            <div className="flex justify-center">
+              <SheiLoader size="md" loadingText="Loading..." />
+            </div>
+          }
+        >
+          <UpdatePasswordForm type="user" />
+        </Suspense>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin-login/forgot-password/page.tsx
+++ b/src/app/admin-login/forgot-password/page.tsx
@@ -1,0 +1,32 @@
+// app/admin-login/forgot-password/page.tsx
+"use client";
+
+import { Suspense } from "react";
+import { DesktopLayout } from "@/app/components/layout/auth/AuthDesktop";
+import { MobileLayout } from "@/app/components/layout/auth/AuthMobile";
+import { ForgotPasswordForm } from "@/app/components/auth/ForgotPasswordForm";
+import { SheiLoader } from "@/app/components/ui/SheiLoader/loader";
+
+export default function AdminForgotPasswordPage() {
+  return (
+    <>
+      {/* Mobile */}
+      <div className="block md:hidden">
+        <MobileLayout>
+          <Suspense fallback={<SheiLoader size="md" loadingText="Loading..." />}>
+            <ForgotPasswordForm type="admin" />
+          </Suspense>
+        </MobileLayout>
+      </div>
+
+      {/* Desktop */}
+      <div className="hidden md:block">
+        <DesktopLayout isAdmin={true}>
+          <Suspense fallback={<SheiLoader size="md" loadingText="Loading..." />}>
+            <ForgotPasswordForm type="admin" />
+          </Suspense>
+        </DesktopLayout>
+      </div>
+    </>
+  );
+}

--- a/src/app/admin-login/update-password/page.tsx
+++ b/src/app/admin-login/update-password/page.tsx
@@ -1,0 +1,32 @@
+// app/admin-login/update-password/page.tsx
+"use client";
+
+import { Suspense } from "react";
+import { DesktopLayout } from "@/app/components/layout/auth/AuthDesktop";
+import { MobileLayout } from "@/app/components/layout/auth/AuthMobile";
+import { UpdatePasswordForm } from "@/app/components/auth/UpdatePasswordForm";
+import { SheiLoader } from "@/app/components/ui/SheiLoader/loader";
+
+export default function AdminUpdatePasswordPage() {
+  return (
+    <>
+      {/* Mobile */}
+      <div className="block md:hidden">
+        <MobileLayout>
+          <Suspense fallback={<SheiLoader size="md" loadingText="Loading..." />}>
+            <UpdatePasswordForm type="admin" />
+          </Suspense>
+        </MobileLayout>
+      </div>
+
+      {/* Desktop */}
+      <div className="hidden md:block">
+        <DesktopLayout isAdmin={true}>
+          <Suspense fallback={<SheiLoader size="md" loadingText="Loading..." />}>
+            <UpdatePasswordForm type="admin" />
+          </Suspense>
+        </DesktopLayout>
+      </div>
+    </>
+  );
+}

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,0 +1,49 @@
+// app/auth/callback/route.ts
+// Server-side PKCE code exchange for Supabase Auth.
+// Supabase redirects here with ?code=... after verifying the email link.
+// This route exchanges the code for a session (server-side, no verifier issues),
+// then redirects the browser to /auth/update-password.
+//
+// Add to Supabase → Authentication → URL Configuration → Redirect URLs:
+//   http://localhost:3000/auth/callback
+//   https://www.sheihoise.com/auth/callback
+
+import { NextResponse } from "next/server";
+import { createServerClient } from "@supabase/ssr";
+import { cookies } from "next/headers";
+
+export async function GET(request: Request) {
+  const { searchParams, origin } = new URL(request.url);
+  const code = searchParams.get("code");
+
+  if (code) {
+    const cookieStore = await cookies();
+
+    const supabase = createServerClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      {
+        cookies: {
+          getAll() {
+            return cookieStore.getAll();
+          },
+          setAll(cookiesToSet) {
+            cookiesToSet.forEach(({ name, value, options }) =>
+              cookieStore.set(name, value, options)
+            );
+          },
+        },
+      }
+    );
+
+    const { error } = await supabase.auth.exchangeCodeForSession(code);
+
+    if (!error) {
+      // Session is now stored in cookies — redirect to the update-password page
+      return NextResponse.redirect(`${origin}/auth/update-password`);
+    }
+  }
+
+  // Exchange failed — redirect to update-password which will show the expired-link UI
+  return NextResponse.redirect(`${origin}/auth/update-password?error=link_expired`);
+}

--- a/src/app/auth/update-password/page.tsx
+++ b/src/app/auth/update-password/page.tsx
@@ -1,0 +1,138 @@
+// app/auth/update-password/page.tsx
+//
+// Universal password-reset landing page (PKCE flow).
+//
+// Supabase redirects here with ?code=... after the user clicks the email link.
+// This page exchanges the code for a session, then renders the update-password form.
+//
+// ─── Supabase Dashboard setup ────────────────────────────────────────────────
+//  Authentication → URL Configuration → Redirect URLs — add ALL of these:
+//    https://www.sheihoise.com/auth/update-password   (production)
+//    http://localhost:3000/auth/update-password       (local dev)
+//    http://localhost:3001/auth/update-password       (if you use a different port)
+// ─────────────────────────────────────────────────────────────────────────────
+"use client";
+
+import { useState, useEffect, Suspense } from "react";
+import { useSearchParams } from "next/navigation";
+import { UpdatePasswordForm } from "@/app/components/auth/UpdatePasswordForm";
+import { SheiLoader } from "@/app/components/ui/SheiLoader/loader";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { AlertCircle } from "lucide-react";
+import { supabase } from "@/lib/supabase";
+
+interface ResetContext {
+  type: "admin" | "user";
+  storeSlug: string | null;
+}
+
+function UpdatePasswordWithContext() {
+  const searchParams = useSearchParams();
+  const [context, setContext] = useState<ResetContext | null>(null);
+  const [ready, setReady] = useState(false);
+  const [exchangeError, setExchangeError] = useState<string | null>(null);
+
+  useEffect(() => {
+    // 1. Restore context saved by ForgotPasswordForm
+    let resolved: ResetContext = { type: "admin", storeSlug: null };
+    try {
+      const raw = localStorage.getItem("resetPasswordContext");
+      if (raw) {
+        resolved = JSON.parse(raw) as ResetContext;
+        localStorage.removeItem("resetPasswordContext");
+      }
+    } catch {
+      // keep default
+    }
+    setContext(resolved);
+
+    // 2. Exchange the PKCE ?code= for a Supabase session
+    const code = searchParams.get("code");
+    if (code) {
+      supabase.auth
+        .exchangeCodeForSession(code)
+        .then(({ error }) => {
+          if (error) {
+            setExchangeError(error.message);
+          }
+          setReady(true);
+        });
+    } else {
+      // No code in URL — let UpdatePasswordForm handle session detection
+      // (handles the case where user navigates here directly with a valid session)
+      setReady(true);
+    }
+  }, [searchParams]);
+
+  if (!context || !ready) {
+    return (
+      <div className="flex justify-center">
+        <SheiLoader size="md" loadingText="Verifying reset link..." />
+      </div>
+    );
+  }
+
+  // Code exchange failed — show error with retry link derived from context
+  if (exchangeError) {
+    const forgotHref =
+      context.type === "admin"
+        ? "/admin-login/forgot-password"
+        : `/${context.storeSlug}/forgot-password`;
+
+    return (
+      <Card className="shadow-lg border-border">
+        <CardHeader className="text-center space-y-4">
+          <div className="mx-auto w-16 h-16 bg-linear-to-br from-red-100 to-red-200 dark:from-red-900/20 dark:to-red-800/20 rounded-full flex items-center justify-center">
+            <AlertCircle className="h-8 w-8 text-red-600 dark:text-red-500" />
+          </div>
+          <CardTitle className="text-xl font-bold">Link Expired</CardTitle>
+          <CardDescription className="text-base">
+            This password reset link has expired or was already used.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="pb-6">
+          <Button
+            type="button"
+            variant="greenish"
+            className="w-full"
+            onClick={() => (window.location.href = forgotHref)}
+          >
+            Request New Reset Link
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <UpdatePasswordForm
+      type={context.type}
+      storeSlug={context.storeSlug ?? undefined}
+    />
+  );
+}
+
+export default function AuthUpdatePasswordPage() {
+  return (
+    <div className="min-h-screen bg-background flex items-center justify-center p-4">
+      <div className="w-full max-w-md">
+        <Suspense
+          fallback={
+            <div className="flex justify-center">
+              <SheiLoader size="md" loadingText="Verifying reset link..." />
+            </div>
+          }
+        >
+          <UpdatePasswordWithContext />
+        </Suspense>
+      </div>
+    </div>
+  );
+}

--- a/src/app/auth/update-password/page.tsx
+++ b/src/app/auth/update-password/page.tsx
@@ -1,16 +1,7 @@
 // app/auth/update-password/page.tsx
-//
-// Universal password-reset landing page (PKCE flow).
-//
-// Supabase redirects here with ?code=... after the user clicks the email link.
-// This page exchanges the code for a session, then renders the update-password form.
-//
-// ─── Supabase Dashboard setup ────────────────────────────────────────────────
-//  Authentication → URL Configuration → Redirect URLs — add ALL of these:
-//    https://www.sheihoise.com/auth/update-password   (production)
-//    http://localhost:3000/auth/update-password       (local dev)
-//    http://localhost:3001/auth/update-password       (if you use a different port)
-// ─────────────────────────────────────────────────────────────────────────────
+// The PKCE code is exchanged server-side in /auth/callback/route.ts.
+// By the time the browser lands here the session cookie is already set.
+// This page just reads the stored context and renders the update-password form.
 "use client";
 
 import { useState, useEffect, Suspense } from "react";
@@ -26,7 +17,6 @@ import {
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { AlertCircle } from "lucide-react";
-import { supabase } from "@/lib/supabase";
 
 interface ResetContext {
   type: "admin" | "user";
@@ -36,11 +26,11 @@ interface ResetContext {
 function UpdatePasswordWithContext() {
   const searchParams = useSearchParams();
   const [context, setContext] = useState<ResetContext | null>(null);
-  const [ready, setReady] = useState(false);
-  const [exchangeError, setExchangeError] = useState<string | null>(null);
+
+  // If the callback route failed it appends ?error=link_expired
+  const hasError = searchParams.get("error") === "link_expired";
 
   useEffect(() => {
-    // 1. Restore context saved by ForgotPasswordForm
     let resolved: ResetContext = { type: "admin", storeSlug: null };
     try {
       const raw = localStorage.getItem("resetPasswordContext");
@@ -52,35 +42,17 @@ function UpdatePasswordWithContext() {
       // keep default
     }
     setContext(resolved);
+  }, []);
 
-    // 2. Exchange the PKCE ?code= for a Supabase session
-    const code = searchParams.get("code");
-    if (code) {
-      supabase.auth
-        .exchangeCodeForSession(code)
-        .then(({ error }) => {
-          if (error) {
-            setExchangeError(error.message);
-          }
-          setReady(true);
-        });
-    } else {
-      // No code in URL — let UpdatePasswordForm handle session detection
-      // (handles the case where user navigates here directly with a valid session)
-      setReady(true);
-    }
-  }, [searchParams]);
-
-  if (!context || !ready) {
+  if (!context) {
     return (
       <div className="flex justify-center">
-        <SheiLoader size="md" loadingText="Verifying reset link..." />
+        <SheiLoader size="md" loadingText="Loading..." />
       </div>
     );
   }
 
-  // Code exchange failed — show error with retry link derived from context
-  if (exchangeError) {
+  if (hasError) {
     const forgotHref =
       context.type === "admin"
         ? "/admin-login/forgot-password"
@@ -94,7 +66,8 @@ function UpdatePasswordWithContext() {
           </div>
           <CardTitle className="text-xl font-bold">Link Expired</CardTitle>
           <CardDescription className="text-base">
-            This password reset link has expired or was already used.
+            This password reset link has expired or was already used. Please
+            request a new one.
           </CardDescription>
         </CardHeader>
         <CardContent className="pb-6">
@@ -126,7 +99,7 @@ export default function AuthUpdatePasswordPage() {
         <Suspense
           fallback={
             <div className="flex justify-center">
-              <SheiLoader size="md" loadingText="Verifying reset link..." />
+              <SheiLoader size="md" loadingText="Loading..." />
             </div>
           }
         >

--- a/src/app/components/auth/Customer/LoginSteps.tsx
+++ b/src/app/components/auth/Customer/LoginSteps.tsx
@@ -2,6 +2,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -382,6 +383,7 @@ interface PasswordStepProps {
   onLogin: () => void;
   onBack: () => void;
   isLoggingIn: boolean;
+  storeSlug: string;
 }
 
 export function PasswordStep({
@@ -392,6 +394,7 @@ export function PasswordStep({
   onLogin,
   onBack,
   isLoggingIn,
+  storeSlug,
 }: PasswordStepProps) {
   const [showPassword, setShowPassword] = useState(false);
 
@@ -458,9 +461,17 @@ export function PasswordStep({
           {/* ✅ Added Password Strength Checker */}
           <PasswordStrength password={password} />
           
-          <p className="text-sm text-muted-foreground">
-            Enter password to access your account
-          </p>
+          <div className="flex items-center justify-between">
+            <p className="text-sm text-muted-foreground">
+              Enter password to access your account
+            </p>
+            <Link
+              href={`/${storeSlug}/forgot-password`}
+              className="text-sm text-muted-foreground hover:text-foreground hover:underline transition-colors"
+            >
+              Forgot Password?
+            </Link>
+          </div>
         </div>
 
         <div className="space-y-4">

--- a/src/app/components/auth/ForgotPasswordForm.tsx
+++ b/src/app/components/auth/ForgotPasswordForm.tsx
@@ -62,9 +62,11 @@ export function ForgotPasswordForm({ type }: ForgotPasswordFormProps) {
       JSON.stringify({ type, storeSlug: storeSlug ?? null })
     );
 
-    // Single whitelisted redirect URL — add https://www.sheihoise.com/auth/update-password
-    // to Supabase Auth > URL Configuration > Redirect URLs
-    const redirectTo = `${origin}/auth/update-password`;
+    // Server-side callback route handles the PKCE code exchange.
+    // Add to Supabase → Authentication → URL Configuration → Redirect URLs:
+    //   http://localhost:3000/auth/callback
+    //   https://www.sheihoise.com/auth/callback
+    const redirectTo = `${origin}/auth/callback`;
 
     const { error: resetError } = await supabase.auth.resetPasswordForEmail(
       values.email,

--- a/src/app/components/auth/ForgotPasswordForm.tsx
+++ b/src/app/components/auth/ForgotPasswordForm.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { SheiLoader } from "../ui/SheiLoader/loader";
+import { useSheiNotification } from "@/lib/hook/useSheiNotification";
+import { supabase } from "@/lib/supabase";
+import { Mail, ArrowLeft, KeyRound } from "lucide-react";
+
+const forgotPasswordSchema = z.object({
+  email: z
+    .string()
+    .min(1, "Email is required")
+    .email("Please enter a valid email address"),
+});
+
+type ForgotPasswordFormValues = z.infer<typeof forgotPasswordSchema>;
+
+interface ForgotPasswordFormProps {
+  type: "admin" | "user";
+}
+
+export function ForgotPasswordForm({ type }: ForgotPasswordFormProps) {
+  const params = useParams();
+  const router = useRouter();
+  const storeSlug = type === "user" ? (params.store_slug as string) : undefined;
+  const { success, error } = useSheiNotification();
+  const [isSubmitted, setIsSubmitted] = useState(false);
+
+  const backToLoginHref =
+    type === "admin" ? "/admin-login" : `/${storeSlug}/login`;
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+    getValues,
+  } = useForm<ForgotPasswordFormValues>({
+    resolver: zodResolver(forgotPasswordSchema),
+    defaultValues: { email: "" },
+  });
+
+  const onSubmit = async (values: ForgotPasswordFormValues) => {
+    const origin = window.location.origin;
+
+    // Persist context so the /auth/update-password page knows where to redirect back
+    localStorage.setItem(
+      "resetPasswordContext",
+      JSON.stringify({ type, storeSlug: storeSlug ?? null })
+    );
+
+    // Single whitelisted redirect URL — add https://www.sheihoise.com/auth/update-password
+    // to Supabase Auth > URL Configuration > Redirect URLs
+    const redirectTo = `${origin}/auth/update-password`;
+
+    const { error: resetError } = await supabase.auth.resetPasswordForEmail(
+      values.email,
+      { redirectTo }
+    );
+
+    if (resetError) {
+      error(resetError.message || "Failed to send reset email. Please try again.");
+      return;
+    }
+
+    setIsSubmitted(true);
+    success("Password reset email sent! Please check your inbox.");
+  };
+
+  if (isSubmitted) {
+    return (
+      <Card className="shadow-lg border-border">
+        <CardHeader className="text-center space-y-4">
+          <div className="mx-auto w-16 h-16 bg-linear-to-br from-green-100 to-green-200 dark:from-green-900/20 dark:to-green-800/20 rounded-full flex items-center justify-center">
+            <Mail className="h-8 w-8 text-green-600 dark:text-green-500" />
+          </div>
+          <CardTitle className="text-2xl font-bold">Check Your Email</CardTitle>
+          <CardDescription className="text-base">
+            We&apos;ve sent a password reset link to{" "}
+            <strong className="text-foreground">{getValues("email")}</strong>
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4 pt-2 pb-6">
+          <p className="text-sm text-muted-foreground text-center">
+            Click the link in your email to reset your password. The link will
+            expire in 1 hour. Check your spam folder if you don&apos;t see it.
+          </p>
+          <Button
+            type="button"
+            variant="outline"
+            className="w-full"
+            onClick={() => router.push(backToLoginHref)}
+          >
+            <ArrowLeft className="h-4 w-4 mr-2" />
+            Back to Login
+          </Button>
+          <p className="text-center text-sm text-muted-foreground">
+            Didn&apos;t receive it?{" "}
+            <button
+              type="button"
+              onClick={() => setIsSubmitted(false)}
+              className="text-primary hover:underline font-medium"
+            >
+              Try again
+            </button>
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="shadow-lg border-border">
+      <CardHeader className="text-center space-y-4">
+        <div className="mx-auto w-16 h-16 bg-linear-to-br from-chart-2/10 to-chart-2/20 rounded-full flex items-center justify-center">
+          <KeyRound className="h-8 w-8 text-chart-2" />
+        </div>
+        <CardTitle className="text-2xl font-bold">Forgot Password?</CardTitle>
+        <CardDescription className="text-base text-muted-foreground">
+          Enter your email and we&apos;ll send you a reset link
+        </CardDescription>
+      </CardHeader>
+
+      <CardContent className="pt-2 pb-6">
+        <form
+          onSubmit={handleSubmit(onSubmit)}
+          className="space-y-5"
+          noValidate
+        >
+          <div className="space-y-2">
+            <Label htmlFor="email" className="text-base font-semibold">
+              Email Address
+            </Label>
+            <Input
+              id="email"
+              type="email"
+              placeholder="you@example.com"
+              {...register("email")}
+              disabled={isSubmitting}
+              autoFocus
+              aria-describedby={errors.email ? "email-error" : undefined}
+            />
+            {errors.email && (
+              <p id="email-error" className="text-sm text-destructive">
+                {errors.email.message}
+              </p>
+            )}
+          </div>
+
+          <Button
+            type="submit"
+            className="w-full"
+            variant="greenish"
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? (
+              <>
+                <SheiLoader size="sm" loaderColor="white" className="mr-2" />
+                Sending Reset Link...
+              </>
+            ) : (
+              "Send Reset Link"
+            )}
+          </Button>
+
+          <Button
+            type="button"
+            variant="outline"
+            className="w-full"
+            onClick={() => router.push(backToLoginHref)}
+          >
+            <ArrowLeft className="h-4 w-4 mr-2" />
+            Back to Login
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/components/auth/UpdatePasswordForm.tsx
+++ b/src/app/components/auth/UpdatePasswordForm.tsx
@@ -66,20 +66,30 @@ export function UpdatePasswordForm({
       : `/${storeSlug}/forgot-password`;
 
   useEffect(() => {
+    // Immediately check for an existing session.
+    // exchangeCodeForSession on the parent page fires PASSWORD_RECOVERY before
+    // this component mounts, so onAuthStateChange alone will miss it.
+    // getSession() reads the already-stored session synchronously from storage.
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (session) {
+        setHasSession(true);
+        setIsCheckingSession(false);
+      }
+    });
+
     const {
       data: { subscription },
     } = supabase.auth.onAuthStateChange((event, session) => {
-      if (event === "PASSWORD_RECOVERY") {
+      if (
+        event === "PASSWORD_RECOVERY" ||
+        event === "SIGNED_IN" ||
+        (event === "INITIAL_SESSION" && session)
+      ) {
         setHasSession(true);
         setIsCheckingSession(false);
-      } else if (event === "INITIAL_SESSION") {
-        if (session) {
-          setHasSession(true);
-          setIsCheckingSession(false);
-        } else {
-          // Wait briefly for PASSWORD_RECOVERY to fire before showing error
-          setTimeout(() => setIsCheckingSession(false), 1500);
-        }
+      } else if (event === "INITIAL_SESSION" && !session) {
+        // No session yet — wait briefly in case getSession() resolves it
+        setTimeout(() => setIsCheckingSession(false), 1000);
       }
     });
 

--- a/src/app/components/auth/UpdatePasswordForm.tsx
+++ b/src/app/components/auth/UpdatePasswordForm.tsx
@@ -1,0 +1,302 @@
+"use client";
+
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { useState, useEffect } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { SheiLoader } from "../ui/SheiLoader/loader";
+import { PasswordToggle } from "../common/PasswordToggle";
+import { useSheiNotification } from "@/lib/hook/useSheiNotification";
+import { supabase } from "@/lib/supabase";
+import { KeyRound, ArrowLeft, CheckCircle, AlertCircle } from "lucide-react";
+
+const updatePasswordSchema = z
+  .object({
+    password: z.string().min(6, "Password must be at least 6 characters"),
+    confirmPassword: z.string().min(6, "Password must be at least 6 characters"),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "Passwords don't match",
+    path: ["confirmPassword"],
+  });
+
+type UpdatePasswordFormValues = z.infer<typeof updatePasswordSchema>;
+
+interface UpdatePasswordFormProps {
+  type: "admin" | "user";
+  /** Optional override — used when rendered outside the [store_slug] route (e.g. /auth/update-password) */
+  storeSlug?: string;
+}
+
+export function UpdatePasswordForm({
+  type,
+  storeSlug: storeSlugProp,
+}: UpdatePasswordFormProps) {
+  const params = useParams();
+  const router = useRouter();
+  const { success, error } = useSheiNotification();
+
+  // Use the explicit prop first; fall back to route param for [store_slug] pages
+  const storeSlug =
+    storeSlugProp ?? (type === "user" ? (params.store_slug as string) : undefined);
+
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [isSuccess, setIsSuccess] = useState(false);
+  const [hasSession, setHasSession] = useState(false);
+  const [isCheckingSession, setIsCheckingSession] = useState(true);
+
+  const backToLoginHref =
+    type === "admin" ? "/admin-login" : `/${storeSlug}/login`;
+
+  const forgotPasswordHref =
+    type === "admin"
+      ? "/admin-login/forgot-password"
+      : `/${storeSlug}/forgot-password`;
+
+  useEffect(() => {
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((event, session) => {
+      if (event === "PASSWORD_RECOVERY") {
+        setHasSession(true);
+        setIsCheckingSession(false);
+      } else if (event === "INITIAL_SESSION") {
+        if (session) {
+          setHasSession(true);
+          setIsCheckingSession(false);
+        } else {
+          // Wait briefly for PASSWORD_RECOVERY to fire before showing error
+          setTimeout(() => setIsCheckingSession(false), 1500);
+        }
+      }
+    });
+
+    return () => subscription.unsubscribe();
+  }, []);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<UpdatePasswordFormValues>({
+    resolver: zodResolver(updatePasswordSchema),
+    defaultValues: { password: "", confirmPassword: "" },
+  });
+
+  const onSubmit = async (values: UpdatePasswordFormValues) => {
+    const { error: updateError } = await supabase.auth.updateUser({
+      password: values.password,
+    });
+
+    if (updateError) {
+      error(updateError.message || "Failed to update password. Please try again.");
+      return;
+    }
+
+    setIsSuccess(true);
+    success("Password updated successfully!");
+
+    setTimeout(() => {
+      router.push(backToLoginHref);
+    }, 2000);
+  };
+
+  if (isCheckingSession) {
+    return (
+      <Card className="shadow-lg border-border">
+        <CardHeader className="text-center space-y-4">
+          <div className="mx-auto">
+            <SheiLoader size="lg" loaderColor="primary" />
+          </div>
+          <CardTitle className="text-xl font-bold">Verifying Link</CardTitle>
+          <CardDescription>
+            Please wait while we verify your reset link...
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  if (!hasSession) {
+    return (
+      <Card className="shadow-lg border-border">
+        <CardHeader className="text-center space-y-4">
+          <div className="mx-auto w-16 h-16 bg-linear-to-br from-red-100 to-red-200 dark:from-red-900/20 dark:to-red-800/20 rounded-full flex items-center justify-center">
+            <AlertCircle className="h-8 w-8 text-red-600 dark:text-red-500" />
+          </div>
+          <CardTitle className="text-xl font-bold">
+            Invalid or Expired Link
+          </CardTitle>
+          <CardDescription className="text-base">
+            This password reset link is invalid or has expired. Please request a
+            new one.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3 pb-6">
+          <Button
+            type="button"
+            variant="greenish"
+            className="w-full"
+            onClick={() => router.push(forgotPasswordHref)}
+          >
+            Request New Reset Link
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            className="w-full"
+            onClick={() => router.push(backToLoginHref)}
+          >
+            <ArrowLeft className="h-4 w-4 mr-2" />
+            Back to Login
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (isSuccess) {
+    return (
+      <Card className="shadow-lg border-border">
+        <CardHeader className="text-center space-y-4">
+          <div className="mx-auto w-16 h-16 bg-linear-to-br from-green-100 to-green-200 dark:from-green-900/20 dark:to-green-800/20 rounded-full flex items-center justify-center">
+            <CheckCircle className="h-8 w-8 text-green-600 dark:text-green-500" />
+          </div>
+          <CardTitle className="text-2xl font-bold">Password Updated!</CardTitle>
+          <CardDescription className="text-base">
+            Your password has been updated successfully. Redirecting to
+            login...
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex justify-center pb-6">
+          <SheiLoader size="md" loaderColor="primary" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="shadow-lg border-border">
+      <CardHeader className="text-center space-y-4">
+        <div className="mx-auto w-16 h-16 bg-linear-to-br from-chart-2/10 to-chart-2/20 rounded-full flex items-center justify-center">
+          <KeyRound className="h-8 w-8 text-chart-2" />
+        </div>
+        <CardTitle className="text-2xl font-bold">Set New Password</CardTitle>
+        <CardDescription className="text-base text-muted-foreground">
+          Create a strong new password for your account
+        </CardDescription>
+      </CardHeader>
+
+      <CardContent className="pt-2 pb-6">
+        <form
+          onSubmit={handleSubmit(onSubmit)}
+          className="space-y-5"
+          noValidate
+        >
+          {/* New Password */}
+          <div className="space-y-2">
+            <Label htmlFor="password" className="text-base font-semibold">
+              New Password
+            </Label>
+            <div className="relative">
+              <Input
+                id="password"
+                type={showPassword ? "text" : "password"}
+                placeholder="••••••••"
+                {...register("password")}
+                disabled={isSubmitting}
+                className="pr-12"
+                autoFocus
+                aria-describedby={errors.password ? "password-error" : undefined}
+              />
+              <div className="absolute right-2 top-1/2 -translate-y-1/2">
+                <PasswordToggle
+                  show={showPassword}
+                  onToggle={() => setShowPassword(!showPassword)}
+                  size={20}
+                  className="hover:bg-accent/20"
+                />
+              </div>
+            </div>
+            {errors.password && (
+              <p id="password-error" className="text-sm text-destructive">
+                {errors.password.message}
+              </p>
+            )}
+          </div>
+
+          {/* Confirm Password */}
+          <div className="space-y-2">
+            <Label htmlFor="confirmPassword" className="text-base font-semibold">
+              Confirm New Password
+            </Label>
+            <div className="relative">
+              <Input
+                id="confirmPassword"
+                type={showConfirmPassword ? "text" : "password"}
+                placeholder="••••••••"
+                {...register("confirmPassword")}
+                disabled={isSubmitting}
+                className="pr-12"
+                aria-describedby={
+                  errors.confirmPassword ? "confirm-error" : undefined
+                }
+              />
+              <div className="absolute right-2 top-1/2 -translate-y-1/2">
+                <PasswordToggle
+                  show={showConfirmPassword}
+                  onToggle={() => setShowConfirmPassword(!showConfirmPassword)}
+                  size={20}
+                  className="hover:bg-accent/20"
+                />
+              </div>
+            </div>
+            {errors.confirmPassword && (
+              <p id="confirm-error" className="text-sm text-destructive">
+                {errors.confirmPassword.message}
+              </p>
+            )}
+          </div>
+
+          <Button
+            type="submit"
+            className="w-full"
+            variant="greenish"
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? (
+              <>
+                <SheiLoader size="sm" loaderColor="white" className="mr-2" />
+                Updating Password...
+              </>
+            ) : (
+              "Update Password"
+            )}
+          </Button>
+
+          <Button
+            type="button"
+            variant="outline"
+            className="w-full"
+            onClick={() => router.push(backToLoginHref)}
+          >
+            <ArrowLeft className="h-4 w-4 mr-2" />
+            Back to Login
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/components/common/UserForm.tsx
+++ b/src/app/components/common/UserForm.tsx
@@ -6,6 +6,7 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useState, useEffect } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
+import Link from "next/link";
 
 import { 
   LoginFormSchema, 
@@ -204,6 +205,18 @@ export function UserForm({
         {/* ✅ Password Strength Indicator (only for signup) */}
         {mode === "signup" && (
           <PasswordStrength password={watchedPassword} />
+        )}
+
+        {/* Forgot Password link — only for admin login mode */}
+        {isAdmin && mode !== "signup" && (
+          <div className="flex justify-end">
+            <Link
+              href="/admin-login/forgot-password"
+              className="text-sm text-muted-foreground hover:text-foreground hover:underline transition-colors"
+            >
+              Forgot Password?
+            </Link>
+          </div>
         )}
       </div>
 

--- a/src/lib/queries/customerAuth/customerSignup.ts
+++ b/src/lib/queries/customerAuth/customerSignup.ts
@@ -24,7 +24,19 @@ export const signupQueries = {
       options: { data: { email: email.toLowerCase(), role: "customer" } },
     });
 
-    if (error) throw error;
+    if (error) {
+      // Auth user already exists — sign in instead of failing
+      if (error.message.toLowerCase().includes("already registered")) {
+        const { data: signInData, error: signInError } = await supabase.auth.signInWithPassword({
+          email: email.toLowerCase(),
+          password,
+        });
+        if (signInError) throw signInError;
+        return signInData;
+      }
+      throw error;
+    }
+
     return data;
   },
 
@@ -52,19 +64,20 @@ export const signupQueries = {
     return store;
   },
 
-  createCustomer: async (email: string, authUserId?: string) => {
+  createCustomer: async (email: string, authUserId?: string, phone?: string) => {
     const { data: customer, error } = await supabase
       .from("store_customers")
       .insert({
         email: email.toLowerCase(),
         auth_user_id: authUserId,
         name: email.split("@")[0],
+        phone: phone || "",
       })
       .select("id")
       .single();
 
     if (error) {
-      console.error("Failed to create customer:", error);
+      console.error("Failed to create customer:", error?.message, error?.code, error?.details);
       // If customer already exists, try to fetch existing one
       const { data: existingCustomer } = await supabase
         .from("store_customers")


### PR DESCRIPTION
Summary

- Implements a full forgot password / reset password flow for both admin and store customers using Supabase PKCE auth
- Adds a shared /auth/callback route that handles the server-side code exchange before redirecting to the update-password page
- Fixes SignupForm to read phone number from URL params when redirected from LoginForm
- Fixes LoginForm to pass storeSlug to the login step component
- Updates tsconfig.json to use moduleResolution: bundler (recommended for Next.js App Router)


Auth Flow

User clicks "Forgot Password"
       ↓
ForgotPasswordForm → saves context to localStorage → calls supabase.auth.resetPasswordForEmail()
       ↓
Supabase sends email → user clicks link → /auth/callback?code=xxx
       ↓
Server exchanges code for session (PKCE) → redirects to /auth/update-password
       ↓
UpdatePasswordForm reads context from localStorage → renders correct type (admin/user)
       ↓
User sets new password → redirected back to their login page
Supabase Config Required
Add these to Authentication → URL Configuration → Redirect URLs:


http://localhost:3000/auth/callback
https://www.sheihoise.com/auth/callback