### PR TITLE
Store Homepage — Featured Bento Layout & Shop Page AND Featured Product — Toggle, Filter & Table Badge

### DIFF
--- a/src/app/[store_slug]/page.tsx
+++ b/src/app/[store_slug]/page.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useState, useRef } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { motion } from "framer-motion";
-import { ShoppingBag, ArrowRight, Package, Loader2, Sparkles } from "lucide-react";
+import { ShoppingBag, ArrowRight, Package, Loader2, Sparkles, Tag } from "lucide-react";
 import { getStoreBySlugFull, StoreFull } from "@/lib/queries/stores/getStoreBySlugFull";
 import { getFeaturedProducts } from "@/lib/queries/products/getFeaturedProducts";
 import { getCategoriesQuery } from "@/lib/queries/categories/getCategories";
@@ -105,14 +105,14 @@ export default function StoreHomePage({ params }: StoreHomePageProps) {
   const hasBanner = !!storeData?.banner_url;
 
   return (
-    <div className="min-h-screen bg-white dark:bg-gray-950">
+    <div className="min-h-screen bg-[#F8F8F6] dark:bg-gray-950">
 
       {/* ══════════════════════════════════════════
-          BANNER
+          HERO BANNER
       ══════════════════════════════════════════ */}
       <section className="relative w-full overflow-hidden">
-        {hasBanner ? (
-          <div className="relative w-full h-64 sm:h-80 lg:h-110">
+        {hasBanner && (
+          <div className="relative w-full h-72 sm:h-96 lg:h-120">
             <Image
               src={storeData!.banner_url!}
               alt={`${storeName} banner`}
@@ -121,31 +121,34 @@ export default function StoreHomePage({ params }: StoreHomePageProps) {
               className="object-cover"
               sizes="100vw"
             />
-            <div className="absolute inset-0 bg-linear-to-b from-transparent via-transparent to-black/55" />
+            {/* rich cinematic overlay */}
+            <div className="absolute inset-0 bg-linear-to-b from-black/10 via-black/5 to-black/70" />
+            {/* subtle vignette */}
+            <div className="absolute inset-0 bg-linear-to-r from-black/20 via-transparent to-black/20" />
           </div>
-        ) : null}
+        )}
 
-        {/* Store identity — overlaid on banner bottom when banner exists */}
+        {/* Identity overlaid on banner */}
         {hasBanner && (
           <div className="absolute bottom-0 inset-x-0">
-            <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pb-5 flex items-end justify-between gap-4">
+            <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pb-7 flex items-end justify-between gap-4">
               <motion.div
-                initial={{ opacity: 0, y: 10 }}
+                initial={{ opacity: 0, y: 14 }}
                 animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.38 }}
-                className="flex items-center gap-3"
+                transition={{ duration: 0.45, ease: "easeOut" }}
+                className="flex items-center gap-3.5"
               >
                 {storeData?.logo_url && (
-                  <div className="shrink-0 rounded-xl overflow-hidden border-2 border-white/30 shadow-lg">
-                    <Image src={storeData.logo_url} alt={storeName} width={52} height={52} className="object-cover" />
+                  <div className="shrink-0 w-14 h-14 rounded-2xl overflow-hidden ring-2 ring-white/25 shadow-xl">
+                    <Image src={storeData.logo_url} alt={storeName} width={56} height={56} className="object-cover w-full h-full" />
                   </div>
                 )}
                 <div>
-                  <h1 className="text-xl sm:text-2xl font-black tracking-widest leading-none text-white drop-shadow">
+                  <h1 className="text-xl sm:text-2xl font-black tracking-widest leading-none text-white drop-shadow-md">
                     {storeName}
                   </h1>
                   {storeData?.description && (
-                    <p className="mt-0.5 text-xs line-clamp-1 max-w-xs text-white/65">
+                    <p className="mt-1 text-xs text-white/60 line-clamp-1 max-w-xs font-medium">
                       {storeData.description}
                     </p>
                   )}
@@ -153,14 +156,14 @@ export default function StoreHomePage({ params }: StoreHomePageProps) {
               </motion.div>
 
               <motion.div
-                initial={{ opacity: 0, scale: 0.9 }}
-                animate={{ opacity: 1, scale: 1 }}
-                transition={{ duration: 0.38, delay: 0.08 }}
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.45, delay: 0.1 }}
                 className="shrink-0"
               >
                 <Link
                   href={`/${store_slug}/shop`}
-                  className="inline-flex items-center gap-2 px-5 py-2.5 rounded-full font-bold text-sm active:scale-95 transition-all shadow-md bg-white text-gray-900 hover:bg-gray-100"
+                  className="inline-flex items-center gap-2 px-5 py-2.5 rounded-full font-bold text-sm bg-white text-gray-900 shadow-lg hover:bg-gray-50 active:scale-95 transition-all duration-200"
                 >
                   <ShoppingBag className="h-4 w-4" />
                   Shop All
@@ -171,19 +174,25 @@ export default function StoreHomePage({ params }: StoreHomePageProps) {
         )}
       </section>
 
-      {/* ── No-banner identity strip ── */}
+      {/* ══════════════════════════════════════════
+          NO-BANNER IDENTITY HEADER
+      ══════════════════════════════════════════ */}
       {!hasBanner && (
-        <div className="border-b border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-950">
-          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-5 flex items-center justify-between gap-4">
+        <div className="bg-white dark:bg-gray-950 border-b border-gray-100 dark:border-gray-800/60">
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-7 flex items-center justify-between gap-4">
             <motion.div
-              initial={{ opacity: 0, x: -8 }}
+              initial={{ opacity: 0, x: -10 }}
               animate={{ opacity: 1, x: 0 }}
-              transition={{ duration: 0.35 }}
-              className="flex items-center gap-3 min-w-0"
+              transition={{ duration: 0.38 }}
+              className="flex items-center gap-4 min-w-0"
             >
-              {storeData?.logo_url && (
-                <div className="shrink-0 rounded-xl overflow-hidden border border-gray-100 dark:border-gray-800 shadow-sm">
-                  <Image src={storeData.logo_url} alt={storeName} width={48} height={48} className="object-cover" />
+              {storeData?.logo_url ? (
+                <div className="shrink-0 w-13 h-13 rounded-2xl overflow-hidden border border-gray-100 dark:border-gray-800 shadow-md">
+                  <Image src={storeData.logo_url} alt={storeName} width={52} height={52} className="object-cover w-full h-full" />
+                </div>
+              ) : (
+                <div className="shrink-0 w-13 h-13 rounded-2xl bg-gray-100 dark:bg-gray-800 flex items-center justify-center">
+                  <ShoppingBag className="h-5 w-5 text-gray-400" />
                 </div>
               )}
               <div className="min-w-0">
@@ -191,7 +200,7 @@ export default function StoreHomePage({ params }: StoreHomePageProps) {
                   {storeName}
                 </h1>
                 {storeData?.description && (
-                  <p className="mt-0.5 text-xs text-gray-400 dark:text-gray-500 line-clamp-1 max-w-sm">
+                  <p className="mt-1 text-xs text-gray-400 dark:text-gray-500 line-clamp-1 max-w-sm">
                     {storeData.description}
                   </p>
                 )}
@@ -199,14 +208,14 @@ export default function StoreHomePage({ params }: StoreHomePageProps) {
             </motion.div>
 
             <motion.div
-              initial={{ opacity: 0, x: 8 }}
+              initial={{ opacity: 0, x: 10 }}
               animate={{ opacity: 1, x: 0 }}
-              transition={{ duration: 0.35, delay: 0.07 }}
+              transition={{ duration: 0.38, delay: 0.07 }}
               className="shrink-0"
             >
               <Link
                 href={`/${store_slug}/shop`}
-                className="inline-flex items-center gap-2 px-5 py-2.5 rounded-full font-bold text-sm active:scale-95 transition-all shadow-sm bg-gray-900 dark:bg-white text-white dark:text-gray-900 hover:bg-gray-700 dark:hover:bg-gray-100"
+                className="inline-flex items-center gap-2 px-5 py-2.5 rounded-full font-bold text-sm bg-gray-900 dark:bg-white text-white dark:text-gray-900 shadow-sm hover:bg-gray-700 dark:hover:bg-gray-100 active:scale-95 transition-all duration-200"
               >
                 <ShoppingBag className="h-4 w-4" />
                 Shop All
@@ -217,90 +226,127 @@ export default function StoreHomePage({ params }: StoreHomePageProps) {
       )}
 
       {/* ══════════════════════════════════════════
-          CATEGORY TABS
+          SHOP BY CATEGORY
       ══════════════════════════════════════════ */}
       {categories.length > 0 && (
-        <div className="border-b border-gray-100 dark:border-gray-800">
-          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div className="flex items-center overflow-x-auto scrollbar-hide">
+        <section className="bg-white dark:bg-gray-950/80 border-b border-gray-100 dark:border-gray-800/60">
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12 sm:py-16">
+
+            {/* Section header */}
+            <motion.div
+              initial={{ opacity: 0, y: 10 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.4 }}
+              className="flex items-end justify-between mb-8 sm:mb-10"
+            >
+              <div>
+                <p className="text-[10px] font-extrabold uppercase tracking-[0.28em] text-gray-400 dark:text-gray-500 mb-1.5">
+                  Browse Collection
+                </p>
+                <h2 className="text-2xl sm:text-[1.75rem] font-black text-gray-900 dark:text-white tracking-tight leading-none">
+                  Shop by Category
+                </h2>
+              </div>
               <Link
                 href={`/${store_slug}/shop`}
-                className="shrink-0 px-5 py-3.5 text-xs font-bold text-gray-900 dark:text-white border-b-2 border-gray-900 dark:border-white whitespace-nowrap"
+                className="group hidden sm:inline-flex items-center gap-1.5 text-sm font-semibold text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors duration-200"
               >
-                All
+                View all
+                <ArrowRight className="h-4 w-4 group-hover:translate-x-0.5 transition-transform duration-200" />
               </Link>
-              {categories.map((cat) => (
-                <Link
+            </motion.div>
+
+            {/* Cards grid */}
+            <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3 sm:gap-4">
+              {categories.slice(0, 6).map((cat, i) => (
+                <CategoryCard
                   key={cat.id}
-                  href={`/${store_slug}/shop?category=${encodeURIComponent(cat.name)}`}
-                  className="shrink-0 px-5 py-3.5 text-xs font-medium text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white border-b-2 border-transparent hover:border-gray-300 dark:hover:border-gray-600 whitespace-nowrap transition-colors"
-                >
-                  {cat.name}
-                </Link>
+                  category={cat}
+                  store_slug={store_slug}
+                  index={i}
+                />
               ))}
             </div>
+
+            {/* Mobile view-all */}
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              transition={{ delay: 0.35 }}
+              className="mt-7 text-center sm:hidden"
+            >
+              <Link
+                href={`/${store_slug}/shop`}
+                className="inline-flex items-center gap-1.5 text-sm font-semibold text-gray-500 hover:text-gray-900 dark:hover:text-white transition-colors"
+              >
+                View all categories
+                <ArrowRight className="h-3.5 w-3.5" />
+              </Link>
+            </motion.div>
           </div>
-        </div>
+        </section>
       )}
 
       {/* ══════════════════════════════════════════
-          FEATURED — 5 products, editorial bento
+          FEATURED PRODUCTS
       ══════════════════════════════════════════ */}
-      <section className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-10 pb-24">
+      <section className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-12 pb-24 sm:pt-16">
 
-        {/* Label row */}
-        <div className="flex items-center justify-between mb-7">
-          <div className="flex items-center gap-2">
-            <Sparkles className="h-4 w-4 text-amber-500" />
-            <span className="text-sm font-bold text-gray-900 dark:text-white tracking-tight">
-              Featured picks
-            </span>
-            <span className="text-xs text-gray-400 dark:text-gray-600 font-medium">
-              · {featuredProducts.length} items
-            </span>
+        {/* Section header */}
+        <motion.div
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.4 }}
+          className="flex items-end justify-between mb-7 sm:mb-9"
+        >
+          <div>
+            <p className="text-[10px] font-extrabold uppercase tracking-[0.28em] text-gray-400 dark:text-gray-500 mb-1.5">
+              Hand-picked
+            </p>
+            <div className="flex items-center gap-2.5">
+              <h2 className="text-2xl sm:text-[1.75rem] font-black text-gray-900 dark:text-white tracking-tight leading-none">
+                Featured Picks
+              </h2>
+              <span className="hidden sm:inline-flex items-center gap-1 px-2.5 py-1 rounded-full bg-amber-50 dark:bg-amber-900/20 border border-amber-100 dark:border-amber-800/40 text-[11px] font-bold text-amber-600 dark:text-amber-400">
+                <Sparkles className="h-3 w-3" />
+                {featuredProducts.length}
+              </span>
+            </div>
           </div>
           <Link
             href={`/${store_slug}/shop`}
-            className="inline-flex items-center gap-1 text-xs font-semibold text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors group"
+            className="group inline-flex items-center gap-1.5 text-sm font-semibold text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors duration-200"
           >
-            See all <ArrowRight className="h-3.5 w-3.5 group-hover:translate-x-0.5 transition-transform" />
+            See all
+            <ArrowRight className="h-4 w-4 group-hover:translate-x-0.5 transition-transform duration-200" />
           </Link>
-        </div>
+        </motion.div>
 
-        {/* ── EMPTY STATE ── */}
+        {/* Empty state */}
         {featuredProducts.length === 0 && (
           <div className="flex flex-col items-center justify-center py-24 text-center">
-            <div className="w-14 h-14 rounded-2xl bg-gray-50 dark:bg-gray-900 border border-gray-100 dark:border-gray-800 flex items-center justify-center mb-3">
+            <div className="w-16 h-16 rounded-2xl bg-white dark:bg-gray-900 border border-gray-100 dark:border-gray-800 shadow-sm flex items-center justify-center mb-4">
               <Sparkles className="h-6 w-6 text-gray-300 dark:text-gray-600" />
             </div>
-            <p className="text-sm font-semibold text-gray-500 dark:text-gray-400">No featured products yet</p>
-            <p className="text-xs text-gray-400 dark:text-gray-600 mt-1 mb-5">Check the full shop for all available products.</p>
+            <p className="text-sm font-bold text-gray-600 dark:text-gray-400">No featured products yet</p>
+            <p className="text-xs text-gray-400 dark:text-gray-600 mt-1 mb-6 max-w-50 leading-relaxed">
+              Check the full shop for all available products.
+            </p>
             <Link
               href={`/${store_slug}/shop`}
-              className="inline-flex items-center gap-2 px-5 py-2 rounded-full bg-gray-900 dark:bg-white text-white dark:text-gray-900 text-xs font-semibold hover:bg-gray-700 dark:hover:bg-gray-100 transition-colors"
+              className="inline-flex items-center gap-2 px-6 py-2.5 rounded-full bg-gray-900 dark:bg-white text-white dark:text-gray-900 text-sm font-bold hover:bg-gray-700 dark:hover:bg-gray-100 active:scale-95 transition-all duration-200 shadow-sm"
             >
-              Browse all products <ArrowRight className="h-3.5 w-3.5" />
+              Browse all products
+              <ArrowRight className="h-3.5 w-3.5" />
             </Link>
           </div>
         )}
 
-        {/* ── BENTO GRID (5 products) ── */}
+        {/* Bento grid */}
         {featuredProducts.length > 0 && (
           <>
-            {/*
-              Desktop layout (lg):
-                [  hero (col 1–2, row 1–2)  ] [ card2 (col 3) ] [ card3 (col 4) ]
-                                               [ card4 (col 3) ] [ card5 (col 4) ]
-
-              Tablet (sm):
-                [  hero (col 1–2)  ] [ card2 ] [ card3 ]
-                [ card4 ] [ card5  ]  (row 2 fills)
-
-              Mobile: single column stack
-            */}
             <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 sm:gap-4 auto-rows-auto">
 
-              {/* ── CARD 1 — BIG HERO ── */}
               {featuredProducts[0] && (
                 <ProductCard
                   product={featuredProducts[0]}
@@ -315,7 +361,6 @@ export default function StoreHomePage({ params }: StoreHomePageProps) {
                 />
               )}
 
-              {/* ── CARDS 2–5 — STANDARD ── */}
               {featuredProducts.slice(1).map((product, i) => (
                 <ProductCard
                   key={product.id}
@@ -332,22 +377,22 @@ export default function StoreHomePage({ params }: StoreHomePageProps) {
               ))}
             </div>
 
-            {/* ── BOTTOM CTA ── */}
+            {/* Bottom CTA */}
             <motion.div
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
-              transition={{ delay: 0.35 }}
-              className="mt-12 flex flex-col items-center gap-2"
+              transition={{ delay: 0.4 }}
+              className="mt-14 flex flex-col items-center gap-3"
             >
-              <p className="text-xs text-gray-400 dark:text-gray-600">
+              <p className="text-xs text-gray-400 dark:text-gray-600 tracking-wide">
                 Showing {featuredProducts.length} hand-picked products
               </p>
               <Link
                 href={`/${store_slug}/shop`}
-                className="mt-1 inline-flex items-center gap-2 px-8 py-3 rounded-full border-2 border-gray-200 dark:border-gray-800 text-gray-700 dark:text-gray-300 font-bold text-sm hover:border-gray-900 dark:hover:border-gray-400 hover:text-gray-900 dark:hover:text-white active:scale-95 transition-all"
+                className="inline-flex items-center gap-2.5 px-8 py-3.5 rounded-full border-2 border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-300 font-bold text-sm hover:border-gray-800 dark:hover:border-gray-400 hover:bg-gray-900 dark:hover:bg-white hover:text-white dark:hover:text-gray-900 active:scale-95 transition-all duration-250 group"
               >
                 Browse all products
-                <ArrowRight className="h-4 w-4" />
+                <ArrowRight className="h-4 w-4 group-hover:translate-x-0.5 transition-transform duration-200" />
               </Link>
             </motion.div>
           </>
@@ -358,7 +403,52 @@ export default function StoreHomePage({ params }: StoreHomePageProps) {
 }
 
 /* ─────────────────────────────────────────────────────────
-   PRODUCT CARD  — shared between hero + standard slots
+   CATEGORY CARD
+───────────────────────────────────────────────────────── */
+interface CategoryCardProps {
+  category: Category;
+  store_slug: string;
+  index: number;
+}
+
+function CategoryCard({ category, store_slug, index }: CategoryCardProps) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 16 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay: index * 0.06, duration: 0.38, ease: "easeOut" }}
+    >
+      <Link
+        href={`/${store_slug}/shop?category=${encodeURIComponent(category.name)}`}
+        className="group flex flex-col items-center text-center rounded-2xl bg-white dark:bg-gray-900 border border-gray-100 dark:border-gray-800 shadow-[0_2px_12px_rgba(0,0,0,0.04)] hover:shadow-[0_8px_30px_rgba(0,0,0,0.10)] hover:-translate-y-1 transition-all duration-300 overflow-hidden"
+      >
+        {/* Top micro-accent line on hover */}
+        <div className="w-full h-0.5 bg-linear-to-r from-transparent via-gray-200 to-transparent group-hover:via-gray-400 dark:group-hover:via-gray-500 transition-all duration-300" />
+
+        <div className="flex flex-col items-center gap-3 px-3 py-6 sm:py-7 w-full">
+          {/* Icon container */}
+          <div className="w-11 h-11 rounded-xl bg-gray-50 dark:bg-gray-800 border border-gray-100 dark:border-gray-700 flex items-center justify-center shrink-0 group-hover:bg-gray-100 dark:group-hover:bg-gray-700 transition-colors duration-300">
+            <Tag className="h-4.5 w-4.5 text-gray-400 dark:text-gray-500 group-hover:text-gray-600 dark:group-hover:text-gray-300 transition-colors duration-300" />
+          </div>
+
+          {/* Category name */}
+          <p className="text-[13px] font-bold text-gray-800 dark:text-gray-100 leading-snug line-clamp-2 tracking-tight group-hover:text-gray-900 dark:group-hover:text-white transition-colors duration-200">
+            {category.name}
+          </p>
+
+          {/* Browse CTA */}
+          <span className="flex items-center gap-1 text-[11px] font-semibold text-gray-400 dark:text-gray-500 group-hover:text-gray-700 dark:group-hover:text-gray-300 group-hover:translate-x-0.5 transition-all duration-300">
+            Browse
+            <ArrowRight className="h-3 w-3" />
+          </span>
+        </div>
+      </Link>
+    </motion.div>
+  );
+}
+
+/* ─────────────────────────────────────────────────────────
+   PRODUCT CARD
 ───────────────────────────────────────────────────────── */
 interface ProductCardProps {
   product: Product;
@@ -397,9 +487,9 @@ function ProductCard({
       initial={{ opacity: 0, y: 18 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ delay: index * 0.07, duration: 0.38 }}
-      className={`group relative flex flex-col rounded-2xl overflow-hidden bg-white dark:bg-gray-900 border border-gray-100 dark:border-gray-800 hover:shadow-2xl hover:-translate-y-1 transition-all duration-300 ${className}`}
+      className={`group relative flex flex-col rounded-2xl overflow-hidden bg-white dark:bg-gray-900 border border-gray-100 dark:border-gray-800 shadow-[0_2px_12px_rgba(0,0,0,0.05)] hover:shadow-[0_12px_40px_rgba(0,0,0,0.12)] hover:-translate-y-1.5 transition-all duration-350 ${className}`}
     >
-      {/* ── Image ── */}
+      {/* Image */}
       <Link
         href={`/${store_slug}/product/${product.id}`}
         className={`relative block overflow-hidden bg-gray-50 dark:bg-gray-800 shrink-0 ${imageClassName}`}
@@ -409,7 +499,7 @@ function ProductCard({
             src={imageUrl}
             alt={product.name}
             fill
-            className="object-cover group-hover:scale-[1.04] transition-transform duration-500"
+            className="object-cover group-hover:scale-[1.05] transition-transform duration-500 ease-out"
             sizes={isHero ? "(max-width: 640px) 100vw, 50vw" : "(max-width: 640px) 50vw, 25vw"}
           />
         ) : (
@@ -418,29 +508,29 @@ function ProductCard({
           </div>
         )}
 
-        {/* Gradient scrim at bottom of image for text legibility on hero */}
+        {/* Hero gradient scrim */}
         {isHero && (
-          <div className="absolute inset-0 bg-linear-to-t from-black/60 via-black/10 to-transparent" />
+          <div className="absolute inset-0 bg-linear-to-t from-black/65 via-black/15 to-transparent" />
         )}
 
         {/* Badges */}
-        <div className="absolute top-2.5 left-2.5 flex flex-col gap-1.5 z-10">
+        <div className="absolute top-3 left-3 flex flex-col gap-1.5 z-10">
           {hasDiscount && (
-            <span className="text-[10px] font-black px-2 py-0.5 rounded-full bg-rose-500 text-white shadow-sm">
+            <span className="text-[10px] font-black px-2.5 py-0.5 rounded-full bg-rose-500 text-white shadow-sm tracking-wide">
               -{discountPct}%
             </span>
           )}
           {!inStock && (
-            <span className="text-[10px] font-bold px-2 py-0.5 rounded-full bg-gray-900/80 text-white">
+            <span className="text-[10px] font-bold px-2.5 py-0.5 rounded-full bg-gray-900/80 backdrop-blur-sm text-white">
               Sold out
             </span>
           )}
         </div>
 
-        {/* Hero: price + name inside image */}
+        {/* Hero: name + price inside image */}
         {isHero && (
-          <div className="absolute bottom-0 inset-x-0 p-4 z-10">
-            <p className="text-white font-bold text-base sm:text-lg leading-snug line-clamp-2 drop-shadow">
+          <div className="absolute bottom-0 inset-x-0 p-4 sm:p-5 z-10">
+            <p className="text-white font-bold text-base sm:text-lg leading-snug line-clamp-2 drop-shadow-sm">
               {product.name}
             </p>
             <div className="flex items-center gap-2 mt-1.5">
@@ -448,7 +538,7 @@ function ProductCard({
                 ৳{Number(price).toLocaleString()}
               </span>
               {hasDiscount && (
-                <span className="text-white/60 text-xs line-through">
+                <span className="text-white/55 text-xs line-through font-medium">
                   ৳{Number(product.base_price).toLocaleString()}
                 </span>
               )}
@@ -457,11 +547,11 @@ function ProductCard({
         )}
 
         {/* Desktop hover quick-add */}
-        <div className="absolute inset-x-0 bottom-0 translate-y-full group-hover:translate-y-0 transition-transform duration-300 p-3 hidden sm:block z-20">
+        <div className="absolute inset-x-0 bottom-0 translate-y-full group-hover:translate-y-0 transition-transform duration-300 ease-out p-3 hidden sm:block z-20">
           <button
             onClick={(e) => { e.preventDefault(); onAddToCart(product); }}
             disabled={!inStock || loadingProductId === product.id}
-            className="w-full flex items-center justify-center gap-2 py-2.5 rounded-xl bg-white/95 dark:bg-gray-900/95 backdrop-blur-sm text-gray-900 dark:text-white text-xs font-bold shadow-lg disabled:opacity-50 disabled:cursor-not-allowed hover:bg-white dark:hover:bg-gray-900 transition-colors"
+            className="w-full flex items-center justify-center gap-2 py-2.5 rounded-xl bg-white/96 dark:bg-gray-900/96 backdrop-blur-sm text-gray-900 dark:text-white text-xs font-bold shadow-lg disabled:opacity-50 disabled:cursor-not-allowed hover:bg-white dark:hover:bg-gray-800 transition-colors duration-150"
           >
             {loadingProductId === product.id
               ? <Loader2 className="h-3.5 w-3.5 animate-spin" />
@@ -472,12 +562,12 @@ function ProductCard({
         </div>
       </Link>
 
-      {/* ── Info (standard cards only — hero shows inside image) ── */}
+      {/* Info — standard cards only */}
       {!isHero && (
-        <div className="flex items-start justify-between gap-2 p-3">
+        <div className="flex items-start justify-between gap-2 px-3.5 py-3">
           <div className="flex-1 min-w-0">
             <Link href={`/${store_slug}/product/${product.id}`}>
-              <p className="text-sm font-semibold text-gray-800 dark:text-gray-100 line-clamp-2 leading-snug hover:text-gray-600 dark:hover:text-gray-300 transition-colors">
+              <p className="text-[13px] font-semibold text-gray-800 dark:text-gray-100 line-clamp-2 leading-snug hover:text-gray-600 dark:hover:text-gray-300 transition-colors duration-150">
                 {product.name}
               </p>
             </Link>
@@ -493,12 +583,12 @@ function ProductCard({
             </div>
           </div>
 
-          {/* Mobile add */}
+          {/* Mobile add button */}
           <button
             onClick={() => onAddToCart(product)}
             disabled={!inStock || loadingProductId === product.id}
             aria-label={`Add ${product.name} to cart`}
-            className="sm:hidden shrink-0 flex items-center justify-center w-8 h-8 rounded-xl bg-gray-900 dark:bg-white text-white dark:text-gray-900 disabled:opacity-40 disabled:cursor-not-allowed active:scale-90 transition-all"
+            className="sm:hidden shrink-0 flex items-center justify-center w-8 h-8 rounded-full bg-gray-900 dark:bg-white text-white dark:text-gray-900 disabled:opacity-40 disabled:cursor-not-allowed active:scale-90 transition-all duration-150 shadow-sm"
           >
             {loadingProductId === product.id
               ? <Loader2 className="h-3.5 w-3.5 animate-spin" />
@@ -508,13 +598,13 @@ function ProductCard({
         </div>
       )}
 
-      {/* Hero mobile add button — floats over image */}
+      {/* Hero mobile add button */}
       {isHero && (
         <button
           onClick={() => onAddToCart(product)}
           disabled={!inStock || loadingProductId === product.id}
           aria-label={`Add ${product.name} to cart`}
-          className="sm:hidden absolute bottom-4 right-4 z-20 flex items-center justify-center w-9 h-9 rounded-xl bg-white text-gray-900 shadow-lg disabled:opacity-40 disabled:cursor-not-allowed active:scale-90 transition-all"
+          className="sm:hidden absolute bottom-4 right-4 z-20 flex items-center justify-center w-10 h-10 rounded-full bg-white text-gray-900 shadow-lg disabled:opacity-40 disabled:cursor-not-allowed active:scale-90 transition-all duration-150"
         >
           {loadingProductId === product.id
             ? <Loader2 className="h-4 w-4 animate-spin" />

--- a/src/app/[store_slug]/page.tsx
+++ b/src/app/[store_slug]/page.tsx
@@ -7,6 +7,7 @@ import { motion } from "framer-motion";
 import { ShoppingBag, ArrowRight, Package, Loader2, Sparkles, Tag } from "lucide-react";
 import { getStoreBySlugFull, StoreFull } from "@/lib/queries/stores/getStoreBySlugFull";
 import { getFeaturedProducts } from "@/lib/queries/products/getFeaturedProducts";
+import { clientGetProducts } from "@/lib/queries/products/clientGetProducts";
 import { getCategoriesQuery } from "@/lib/queries/categories/getCategories";
 import { Product } from "@/lib/types/product";
 import { Category } from "@/lib/types/category";
@@ -29,6 +30,7 @@ export default function StoreHomePage({ params }: StoreHomePageProps) {
   const [storeData, setStoreData] = useState<StoreFull | null>(null);
   const [storeExists, setStoreExists] = useState<boolean | null>(null);
   const [featuredProducts, setFeaturedProducts] = useState<Product[]>([]);
+  const [isFeaturedSection, setIsFeaturedSection] = useState(true);
   const [categories, setCategories] = useState<Category[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadingProductId, setLoadingProductId] = useState<string | null>(null);
@@ -51,7 +53,16 @@ export default function StoreHomePage({ params }: StoreHomePageProps) {
         ]);
 
         if (categoriesData.data) setCategories(categoriesData.data);
-        setFeaturedProducts(featured);
+
+        if (featured.length > 0) {
+          setFeaturedProducts(featured);
+          setIsFeaturedSection(true);
+        } else {
+          // No featured products — fall back to latest products
+          const latest = await clientGetProducts(store_slug, 1, 5);
+          setFeaturedProducts(latest.products);
+          setIsFeaturedSection(false);
+        }
       } catch (err) {
         console.error(err);
         showError("Failed to load store data");
@@ -301,16 +312,18 @@ export default function StoreHomePage({ params }: StoreHomePageProps) {
         >
           <div>
             <p className="text-[10px] font-extrabold uppercase tracking-[0.28em] text-gray-400 dark:text-gray-500 mb-1.5">
-              Hand-picked
+              {isFeaturedSection ? "Hand-picked" : "Explore"}
             </p>
             <div className="flex items-center gap-2.5">
               <h2 className="text-2xl sm:text-[1.75rem] font-black text-gray-900 dark:text-white tracking-tight leading-none">
-                Featured Picks
+                {isFeaturedSection ? "Featured Picks" : "Our Collection"}
               </h2>
-              <span className="hidden sm:inline-flex items-center gap-1 px-2.5 py-1 rounded-full bg-amber-50 dark:bg-amber-900/20 border border-amber-100 dark:border-amber-800/40 text-[11px] font-bold text-amber-600 dark:text-amber-400">
-                <Sparkles className="h-3 w-3" />
-                {featuredProducts.length}
-              </span>
+              {isFeaturedSection && (
+                <span className="hidden sm:inline-flex items-center gap-1 px-2.5 py-1 rounded-full bg-amber-50 dark:bg-amber-900/20 border border-amber-100 dark:border-amber-800/40 text-[11px] font-bold text-amber-600 dark:text-amber-400">
+                  <Sparkles className="h-3 w-3" />
+                  {featuredProducts.length}
+                </span>
+              )}
             </div>
           </div>
           <Link
@@ -321,26 +334,6 @@ export default function StoreHomePage({ params }: StoreHomePageProps) {
             <ArrowRight className="h-4 w-4 group-hover:translate-x-0.5 transition-transform duration-200" />
           </Link>
         </motion.div>
-
-        {/* Empty state */}
-        {featuredProducts.length === 0 && (
-          <div className="flex flex-col items-center justify-center py-24 text-center">
-            <div className="w-16 h-16 rounded-2xl bg-white dark:bg-gray-900 border border-gray-100 dark:border-gray-800 shadow-sm flex items-center justify-center mb-4">
-              <Sparkles className="h-6 w-6 text-gray-300 dark:text-gray-600" />
-            </div>
-            <p className="text-sm font-bold text-gray-600 dark:text-gray-400">No featured products yet</p>
-            <p className="text-xs text-gray-400 dark:text-gray-600 mt-1 mb-6 max-w-50 leading-relaxed">
-              Check the full shop for all available products.
-            </p>
-            <Link
-              href={`/${store_slug}/shop`}
-              className="inline-flex items-center gap-2 px-6 py-2.5 rounded-full bg-gray-900 dark:bg-white text-white dark:text-gray-900 text-sm font-bold hover:bg-gray-700 dark:hover:bg-gray-100 active:scale-95 transition-all duration-200 shadow-sm"
-            >
-              Browse all products
-              <ArrowRight className="h-3.5 w-3.5" />
-            </Link>
-          </div>
-        )}
 
         {/* Bento grid */}
         {featuredProducts.length > 0 && (

--- a/src/app/[store_slug]/page.tsx
+++ b/src/app/[store_slug]/page.tsx
@@ -1,104 +1,38 @@
 "use client";
 
-import React, { useEffect, useState, useCallback, useRef } from "react";
-import { useSearchParams } from "next/navigation";
-import { useSheiNotification } from "@/lib/hook/useSheiNotification";
-import useCartStore from "@/lib/store/cartStore";
-import ProductGrid from "../components/products/ProductGrid";
-import ProductFilterSection from "@/app/components/products/ProductFilterSection";
-import { StorePageSkeleton } from "../components/skeletons/StorePageSkeleton";
-import { getStoreIdBySlug } from "@/lib/queries/stores/getStoreIdBySlug";
+import React, { useEffect, useState, useRef } from "react";
+import Link from "next/link";
+import Image from "next/image";
+import { motion } from "framer-motion";
+import { ShoppingBag, ArrowRight, Package, Loader2, Sparkles } from "lucide-react";
+import { getStoreBySlugFull, StoreFull } from "@/lib/queries/stores/getStoreBySlugFull";
+import { getFeaturedProducts } from "@/lib/queries/products/getFeaturedProducts";
 import { getCategoriesQuery } from "@/lib/queries/categories/getCategories";
-import { clientGetProducts } from "@/lib/queries/products/clientGetProducts";
 import { Product } from "@/lib/types/product";
 import { Category } from "@/lib/types/category";
+import { StoreHomePageSkeleton } from "../components/skeletons/StoreHomePageSkeleton";
 import NotFoundPage from "../not-found";
+import useCartStore from "@/lib/store/cartStore";
+import { useSheiNotification } from "@/lib/hook/useSheiNotification";
 import { AddToCartType } from "@/lib/schema/checkoutSchema";
-import { Loader2 } from "lucide-react";
-import { motion } from "framer-motion";
 
-interface StorePageProps {
+interface StoreHomePageProps {
   params: Promise<{ store_slug: string }>;
+  store?: StoreFull;
 }
 
-export default function StorePage({ params }: StorePageProps) {
+export default function StoreHomePage({ params }: StoreHomePageProps) {
+  const { store_slug } = React.use(params);
   const { success, error: showError } = useSheiNotification();
   const { addToCart } = useCartStore();
-  const { store_slug } = React.use(params);
-  const searchParams = useSearchParams();
 
+  const [storeData, setStoreData] = useState<StoreFull | null>(null);
   const [storeExists, setStoreExists] = useState<boolean | null>(null);
-  const [products, setProducts] = useState<Product[]>([]);
+  const [featuredProducts, setFeaturedProducts] = useState<Product[]>([]);
   const [categories, setCategories] = useState<Category[]>([]);
-  const [loadingProductId, setLoadingProductId] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
-  const [loadingMore, setLoadingMore] = useState(false);
-
-  const [activeCategory, setActiveCategory] = useState<string>(
-    searchParams.get("category") || "All Products",
-  );
-  const [searchQuery, setSearchQuery] = useState<string>(
-    searchParams.get("search") || "",
-  );
-
-  const [currentPage, setCurrentPage] = useState(1);
-  const [hasMore, setHasMore] = useState(true);
-  const [totalProducts, setTotalProducts] = useState(0);
-
-  const ITEMS_PER_PAGE = 10;
-  const isLoadingRef = useRef(false);
-  const storeIdRef = useRef<string | null>(null);
+  const [loadingProductId, setLoadingProductId] = useState<string | null>(null);
   const initializedRef = useRef(false);
-
-  const updateURLParams = (category: string, search: string) => {
-    const p = new URLSearchParams();
-    if (category !== "All Products") p.set("category", category);
-    if (search.trim()) p.set("search", search.trim());
-    const qs = p.toString();
-    window.history.replaceState({}, "", `/${store_slug}${qs ? `?${qs}` : ""}`);
-  };
-
-  const loadProducts = useCallback(
-    async (
-      page: number,
-      category: string,
-      search: string,
-      isInitialLoad: boolean = false,
-    ) => {
-      if (isLoadingRef.current) return;
-      isLoadingRef.current = true;
-      try {
-        if (isInitialLoad) setLoading(true);
-        else setLoadingMore(true);
-
-        const categoryFilter =
-          category === "All Products" ? undefined : category;
-        const searchFilter = search.trim() || undefined;
-
-        const result = await clientGetProducts(
-          store_slug,
-          page,
-          ITEMS_PER_PAGE,
-          categoryFilter,
-          searchFilter,
-        );
-
-        if (isInitialLoad) setProducts(result.products);
-        else setProducts((prev) => [...prev, ...result.products]);
-
-        setHasMore(result.hasMore);
-        setTotalProducts(result.totalCount);
-      } catch (err) {
-        console.error(err);
-        showError("Failed to load products");
-      } finally {
-        if (isInitialLoad) setLoading(false);
-        else setLoadingMore(false);
-        isLoadingRef.current = false;
-      }
-    },
-    [store_slug, showError],
-  );
 
   useEffect(() => {
     if (initializedRef.current) return;
@@ -106,95 +40,45 @@ export default function StorePage({ params }: StorePageProps) {
 
     async function init() {
       try {
-        const storeId = await getStoreIdBySlug(store_slug);
-        if (!storeId) {
-          setStoreExists(false);
-          return;
-        }
-
-        storeIdRef.current = storeId;
+        const fullStore = await getStoreBySlugFull(store_slug);
+        if (!fullStore) { setStoreExists(false); return; }
+        setStoreData(fullStore);
         setStoreExists(true);
 
-        const [categoriesData] = await Promise.all([
-          getCategoriesQuery(storeId),
-          loadProducts(1, activeCategory, searchQuery, true),
+        const [categoriesData, featured] = await Promise.all([
+          getCategoriesQuery(fullStore.id),
+          getFeaturedProducts(store_slug, 5),
         ]);
 
         if (categoriesData.data) setCategories(categoriesData.data);
+        setFeaturedProducts(featured);
       } catch (err) {
         console.error(err);
         showError("Failed to load store data");
+      } finally {
+        setLoading(false);
       }
     }
 
     init();
-    updateURLParams(activeCategory, searchQuery);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [store_slug]);
 
-  const isFirstFilterRun = useRef(true);
-  useEffect(() => {
-    if (isFirstFilterRun.current) {
-      isFirstFilterRun.current = false;
-      return;
-    }
-    if (!storeIdRef.current) return;
-
-    setCurrentPage(1);
-    setHasMore(true);
-    loadProducts(1, activeCategory, searchQuery, true);
-    updateURLParams(activeCategory, searchQuery);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeCategory, searchQuery]);
-
-  const handleCategoryChange = useCallback((category: string) => {
-    setActiveCategory(category);
-    setSearchQuery("");
-  }, []);
-
-  const handleSearchChange = useCallback((query: string) => {
-    setSearchQuery(query);
-    setActiveCategory("All Products");
-  }, []);
-
-  const handleLoadMore = useCallback(async () => {
-    if (!hasMore || loadingMore || isLoadingRef.current) return;
-    const nextPage = currentPage + 1;
-    setCurrentPage(nextPage);
-    await loadProducts(nextPage, activeCategory, searchQuery, false);
-  }, [
-    hasMore,
-    loadingMore,
-    currentPage,
-    activeCategory,
-    searchQuery,
-    loadProducts,
-  ]);
-
-  const isProductInStock = useCallback((product: Product): boolean => {
+  const isProductInStock = (product: Product): boolean => {
     if (product.variants && product.variants.length > 0) {
-      return product.variants.some((variant) => {
-        const productInventory = variant.product_inventory?.[0];
-        if (productInventory && productInventory.quantity_available > 0)
-          return true;
-        const stock = variant.stock;
-        if (stock && stock.quantity_available > 0) return true;
-        return false;
+      return product.variants.some((v) => {
+        const inv = v.product_inventory?.[0];
+        if (inv && inv.quantity_available > 0) return true;
+        return (v.stock?.quantity_available ?? 0) > 0;
       });
     }
-    const mainProductInventory = product.product_inventory?.[0];
-    if (mainProductInventory && mainProductInventory.quantity_available > 0)
-      return true;
-    const mainStock = product.stock;
-    if (mainStock && mainStock.quantity_available > 0) return true;
-    return false;
-  }, []);
+    const inv = product.product_inventory?.[0];
+    if (inv && inv.quantity_available > 0) return true;
+    return (product.stock?.quantity_available ?? 0) > 0;
+  };
 
   const handleAddToCart = async (product: Product) => {
-    if (!isProductInStock(product)) {
-      showError("This product is out of stock");
-      return;
-    }
+    if (!isProductInStock(product)) { showError("This product is out of stock"); return; }
     setLoadingProductId(product.id);
     try {
       const variant = product.variants?.[0];
@@ -214,115 +98,430 @@ export default function StorePage({ params }: StorePageProps) {
     }
   };
 
-  if (loading && products.length === 0) return <StorePageSkeleton />;
+  if (loading) return <StoreHomePageSkeleton />;
   if (storeExists === false) return <NotFoundPage />;
+
+  const storeName = (storeData?.store_name ?? store_slug.replace(/-/g, " ")).toUpperCase();
+  const hasBanner = !!storeData?.banner_url;
 
   return (
     <div className="min-h-screen bg-white dark:bg-gray-950">
-      <div className="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-        {/* Filter Section */}
-        <ProductFilterSection
-          activeCategory={activeCategory}
-          onCategoryChange={handleCategoryChange}
-          categories={categories}
-          totalProducts={totalProducts}
-          searchQuery={searchQuery}
-          onSearchChange={handleSearchChange}
-        />
 
-        {/* Loading state */}
-        {loading && products.length === 0 ? (
-          <div className="flex justify-center items-center py-32">
-            <Loader2 className="h-7 w-7 animate-spin text-gray-400 dark:text-gray-500" />
-          </div>
-        ) : products.length === 0 ? (
-          <motion.div
-            initial={{ opacity: 0, y: 8 }}
-            animate={{ opacity: 1, y: 0 }}
-            className="flex flex-col items-center justify-center py-32 text-center"
-          >
-            <div className="w-16 h-16 rounded-2xl bg-gray-100 dark:bg-gray-800 flex items-center justify-center mb-4 text-2xl">
-              {searchQuery ? "🔍" : "🛍️"}
-            </div>
-            <p className="text-gray-700 dark:text-gray-200 font-semibold text-base">
-              {searchQuery
-                ? `No results for "${searchQuery}"`
-                : activeCategory === "All Products"
-                  ? "No products available yet"
-                  : `Nothing in "${activeCategory}" yet`}
-            </p>
-            <p className="text-gray-400 dark:text-gray-500 text-sm mt-1">
-              Try a different search or category
-            </p>
-          </motion.div>
-        ) : (
-          <>
-            <ProductGrid
-              store_slug={store_slug}
-              products={products}
-              onAddToCart={handleAddToCart}
-              loadingProductId={loadingProductId}
-              productIndexOffset={(currentPage - 1) * ITEMS_PER_PAGE}
+      {/* ══════════════════════════════════════════
+          BANNER
+      ══════════════════════════════════════════ */}
+      <section className="relative w-full overflow-hidden">
+        {hasBanner ? (
+          <div className="relative w-full h-64 sm:h-80 lg:h-110">
+            <Image
+              src={storeData!.banner_url!}
+              alt={`${storeName} banner`}
+              fill
+              priority
+              className="object-cover"
+              sizes="100vw"
             />
+            <div className="absolute inset-0 bg-linear-to-b from-transparent via-transparent to-black/55" />
+          </div>
+        ) : null}
 
-            {/* Load More */}
-            {hasMore && (
+        {/* Store identity — overlaid on banner bottom when banner exists */}
+        {hasBanner && (
+          <div className="absolute bottom-0 inset-x-0">
+            <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pb-5 flex items-end justify-between gap-4">
               <motion.div
-                initial={{ opacity: 0, y: 12 }}
+                initial={{ opacity: 0, y: 10 }}
                 animate={{ opacity: 1, y: 0 }}
-                className="flex flex-col items-center gap-3 mt-10 mb-16"
+                transition={{ duration: 0.38 }}
+                className="flex items-center gap-3"
               >
-                <button
-                  onClick={handleLoadMore}
-                  disabled={loadingMore}
-                  className="
-                    group flex items-center gap-2.5 h-12 px-10 rounded-2xl
-                    border-2 border-gray-200 dark:border-gray-700
-                    bg-white dark:bg-gray-900
-                    text-gray-700 dark:text-gray-200
-                    font-semibold text-sm
-                    hover:border-gray-900 dark:hover:border-gray-400
-                    hover:text-gray-900 dark:hover:text-white
-                    hover:bg-gray-50 dark:hover:bg-gray-800
-                    active:scale-[0.98] disabled:opacity-50 disabled:cursor-not-allowed
-                    transition-all duration-200 shadow-sm
-                  "
-                >
-                  {loadingMore ? (
-                    <>
-                      <Loader2 className="h-4 w-4 animate-spin" />
-                      Loading more…
-                    </>
-                  ) : (
-                    <>
-                      Show 10 more products
-                      <span className="text-gray-400 dark:text-gray-500 font-normal text-xs group-hover:text-gray-600 dark:group-hover:text-gray-400 transition-colors">
-                        ({totalProducts - products.length} remaining)
-                      </span>
-                    </>
+                {storeData?.logo_url && (
+                  <div className="shrink-0 rounded-xl overflow-hidden border-2 border-white/30 shadow-lg">
+                    <Image src={storeData.logo_url} alt={storeName} width={52} height={52} className="object-cover" />
+                  </div>
+                )}
+                <div>
+                  <h1 className="text-xl sm:text-2xl font-black tracking-widest leading-none text-white drop-shadow">
+                    {storeName}
+                  </h1>
+                  {storeData?.description && (
+                    <p className="mt-0.5 text-xs line-clamp-1 max-w-xs text-white/65">
+                      {storeData.description}
+                    </p>
                   )}
-                </button>
+                </div>
               </motion.div>
-            )}
 
-            {/* End state */}
-            {!hasMore && products.length > 0 && (
               <motion.div
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                className="flex flex-col items-center gap-1 py-12 border-t border-gray-100 dark:border-gray-800"
+                initial={{ opacity: 0, scale: 0.9 }}
+                animate={{ opacity: 1, scale: 1 }}
+                transition={{ duration: 0.38, delay: 0.08 }}
+                className="shrink-0"
               >
-                <p className="text-sm font-semibold text-gray-500 dark:text-gray-400">
-                  All {totalProducts.toLocaleString()} products shown
-                </p>
-                <p className="text-xs text-gray-400 dark:text-gray-500">
-                  You&apos;ve reached the end
-                </p>
+                <Link
+                  href={`/${store_slug}/shop`}
+                  className="inline-flex items-center gap-2 px-5 py-2.5 rounded-full font-bold text-sm active:scale-95 transition-all shadow-md bg-white text-gray-900 hover:bg-gray-100"
+                >
+                  <ShoppingBag className="h-4 w-4" />
+                  Shop All
+                </Link>
               </motion.div>
-            )}
+            </div>
+          </div>
+        )}
+      </section>
+
+      {/* ── No-banner identity strip ── */}
+      {!hasBanner && (
+        <div className="border-b border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-950">
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-5 flex items-center justify-between gap-4">
+            <motion.div
+              initial={{ opacity: 0, x: -8 }}
+              animate={{ opacity: 1, x: 0 }}
+              transition={{ duration: 0.35 }}
+              className="flex items-center gap-3 min-w-0"
+            >
+              {storeData?.logo_url && (
+                <div className="shrink-0 rounded-xl overflow-hidden border border-gray-100 dark:border-gray-800 shadow-sm">
+                  <Image src={storeData.logo_url} alt={storeName} width={48} height={48} className="object-cover" />
+                </div>
+              )}
+              <div className="min-w-0">
+                <h1 className="text-lg sm:text-xl font-black tracking-widest leading-none text-gray-900 dark:text-white truncate">
+                  {storeName}
+                </h1>
+                {storeData?.description && (
+                  <p className="mt-0.5 text-xs text-gray-400 dark:text-gray-500 line-clamp-1 max-w-sm">
+                    {storeData.description}
+                  </p>
+                )}
+              </div>
+            </motion.div>
+
+            <motion.div
+              initial={{ opacity: 0, x: 8 }}
+              animate={{ opacity: 1, x: 0 }}
+              transition={{ duration: 0.35, delay: 0.07 }}
+              className="shrink-0"
+            >
+              <Link
+                href={`/${store_slug}/shop`}
+                className="inline-flex items-center gap-2 px-5 py-2.5 rounded-full font-bold text-sm active:scale-95 transition-all shadow-sm bg-gray-900 dark:bg-white text-white dark:text-gray-900 hover:bg-gray-700 dark:hover:bg-gray-100"
+              >
+                <ShoppingBag className="h-4 w-4" />
+                Shop All
+              </Link>
+            </motion.div>
+          </div>
+        </div>
+      )}
+
+      {/* ══════════════════════════════════════════
+          CATEGORY TABS
+      ══════════════════════════════════════════ */}
+      {categories.length > 0 && (
+        <div className="border-b border-gray-100 dark:border-gray-800">
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div className="flex items-center overflow-x-auto scrollbar-hide">
+              <Link
+                href={`/${store_slug}/shop`}
+                className="shrink-0 px-5 py-3.5 text-xs font-bold text-gray-900 dark:text-white border-b-2 border-gray-900 dark:border-white whitespace-nowrap"
+              >
+                All
+              </Link>
+              {categories.map((cat) => (
+                <Link
+                  key={cat.id}
+                  href={`/${store_slug}/shop?category=${encodeURIComponent(cat.name)}`}
+                  className="shrink-0 px-5 py-3.5 text-xs font-medium text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white border-b-2 border-transparent hover:border-gray-300 dark:hover:border-gray-600 whitespace-nowrap transition-colors"
+                >
+                  {cat.name}
+                </Link>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* ══════════════════════════════════════════
+          FEATURED — 5 products, editorial bento
+      ══════════════════════════════════════════ */}
+      <section className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-10 pb-24">
+
+        {/* Label row */}
+        <div className="flex items-center justify-between mb-7">
+          <div className="flex items-center gap-2">
+            <Sparkles className="h-4 w-4 text-amber-500" />
+            <span className="text-sm font-bold text-gray-900 dark:text-white tracking-tight">
+              Featured picks
+            </span>
+            <span className="text-xs text-gray-400 dark:text-gray-600 font-medium">
+              · {featuredProducts.length} items
+            </span>
+          </div>
+          <Link
+            href={`/${store_slug}/shop`}
+            className="inline-flex items-center gap-1 text-xs font-semibold text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors group"
+          >
+            See all <ArrowRight className="h-3.5 w-3.5 group-hover:translate-x-0.5 transition-transform" />
+          </Link>
+        </div>
+
+        {/* ── EMPTY STATE ── */}
+        {featuredProducts.length === 0 && (
+          <div className="flex flex-col items-center justify-center py-24 text-center">
+            <div className="w-14 h-14 rounded-2xl bg-gray-50 dark:bg-gray-900 border border-gray-100 dark:border-gray-800 flex items-center justify-center mb-3">
+              <Sparkles className="h-6 w-6 text-gray-300 dark:text-gray-600" />
+            </div>
+            <p className="text-sm font-semibold text-gray-500 dark:text-gray-400">No featured products yet</p>
+            <p className="text-xs text-gray-400 dark:text-gray-600 mt-1 mb-5">Check the full shop for all available products.</p>
+            <Link
+              href={`/${store_slug}/shop`}
+              className="inline-flex items-center gap-2 px-5 py-2 rounded-full bg-gray-900 dark:bg-white text-white dark:text-gray-900 text-xs font-semibold hover:bg-gray-700 dark:hover:bg-gray-100 transition-colors"
+            >
+              Browse all products <ArrowRight className="h-3.5 w-3.5" />
+            </Link>
+          </div>
+        )}
+
+        {/* ── BENTO GRID (5 products) ── */}
+        {featuredProducts.length > 0 && (
+          <>
+            {/*
+              Desktop layout (lg):
+                [  hero (col 1–2, row 1–2)  ] [ card2 (col 3) ] [ card3 (col 4) ]
+                                               [ card4 (col 3) ] [ card5 (col 4) ]
+
+              Tablet (sm):
+                [  hero (col 1–2)  ] [ card2 ] [ card3 ]
+                [ card4 ] [ card5  ]  (row 2 fills)
+
+              Mobile: single column stack
+            */}
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 sm:gap-4 auto-rows-auto">
+
+              {/* ── CARD 1 — BIG HERO ── */}
+              {featuredProducts[0] && (
+                <ProductCard
+                  product={featuredProducts[0]}
+                  store_slug={store_slug}
+                  onAddToCart={handleAddToCart}
+                  loadingProductId={loadingProductId}
+                  isProductInStock={isProductInStock}
+                  className="sm:col-span-2 sm:row-span-2"
+                  imageClassName="aspect-[3/4] sm:h-full sm:min-h-[480px]"
+                  isHero
+                  index={0}
+                />
+              )}
+
+              {/* ── CARDS 2–5 — STANDARD ── */}
+              {featuredProducts.slice(1).map((product, i) => (
+                <ProductCard
+                  key={product.id}
+                  product={product}
+                  store_slug={store_slug}
+                  onAddToCart={handleAddToCart}
+                  loadingProductId={loadingProductId}
+                  isProductInStock={isProductInStock}
+                  className=""
+                  imageClassName="aspect-square"
+                  isHero={false}
+                  index={i + 1}
+                />
+              ))}
+            </div>
+
+            {/* ── BOTTOM CTA ── */}
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              transition={{ delay: 0.35 }}
+              className="mt-12 flex flex-col items-center gap-2"
+            >
+              <p className="text-xs text-gray-400 dark:text-gray-600">
+                Showing {featuredProducts.length} hand-picked products
+              </p>
+              <Link
+                href={`/${store_slug}/shop`}
+                className="mt-1 inline-flex items-center gap-2 px-8 py-3 rounded-full border-2 border-gray-200 dark:border-gray-800 text-gray-700 dark:text-gray-300 font-bold text-sm hover:border-gray-900 dark:hover:border-gray-400 hover:text-gray-900 dark:hover:text-white active:scale-95 transition-all"
+              >
+                Browse all products
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+            </motion.div>
           </>
         )}
-      </div>
+      </section>
     </div>
+  );
+}
+
+/* ─────────────────────────────────────────────────────────
+   PRODUCT CARD  — shared between hero + standard slots
+───────────────────────────────────────────────────────── */
+interface ProductCardProps {
+  product: Product;
+  store_slug: string;
+  onAddToCart: (p: Product) => void;
+  loadingProductId: string | null;
+  isProductInStock: (p: Product) => boolean;
+  className: string;
+  imageClassName: string;
+  isHero: boolean;
+  index: number;
+}
+
+function ProductCard({
+  product,
+  store_slug,
+  onAddToCart,
+  loadingProductId,
+  isProductInStock,
+  className,
+  imageClassName,
+  isHero,
+  index,
+}: ProductCardProps) {
+  const inStock = isProductInStock(product);
+  const imageUrl = product.images?.[0] ?? product.primary_image?.image_url ?? null;
+  const price = product.discounted_price ?? product.base_price;
+  const hasDiscount =
+    product.discounted_price != null && product.discounted_price < product.base_price;
+  const discountPct = hasDiscount
+    ? Math.round(((product.base_price - (product.discounted_price ?? 0)) / product.base_price) * 100)
+    : 0;
+
+  return (
+    <motion.article
+      initial={{ opacity: 0, y: 18 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay: index * 0.07, duration: 0.38 }}
+      className={`group relative flex flex-col rounded-2xl overflow-hidden bg-white dark:bg-gray-900 border border-gray-100 dark:border-gray-800 hover:shadow-2xl hover:-translate-y-1 transition-all duration-300 ${className}`}
+    >
+      {/* ── Image ── */}
+      <Link
+        href={`/${store_slug}/product/${product.id}`}
+        className={`relative block overflow-hidden bg-gray-50 dark:bg-gray-800 shrink-0 ${imageClassName}`}
+      >
+        {imageUrl ? (
+          <Image
+            src={imageUrl}
+            alt={product.name}
+            fill
+            className="object-cover group-hover:scale-[1.04] transition-transform duration-500"
+            sizes={isHero ? "(max-width: 640px) 100vw, 50vw" : "(max-width: 640px) 50vw, 25vw"}
+          />
+        ) : (
+          <div className="absolute inset-0 flex items-center justify-center">
+            <Package className="h-10 w-10 text-gray-200 dark:text-gray-700" />
+          </div>
+        )}
+
+        {/* Gradient scrim at bottom of image for text legibility on hero */}
+        {isHero && (
+          <div className="absolute inset-0 bg-linear-to-t from-black/60 via-black/10 to-transparent" />
+        )}
+
+        {/* Badges */}
+        <div className="absolute top-2.5 left-2.5 flex flex-col gap-1.5 z-10">
+          {hasDiscount && (
+            <span className="text-[10px] font-black px-2 py-0.5 rounded-full bg-rose-500 text-white shadow-sm">
+              -{discountPct}%
+            </span>
+          )}
+          {!inStock && (
+            <span className="text-[10px] font-bold px-2 py-0.5 rounded-full bg-gray-900/80 text-white">
+              Sold out
+            </span>
+          )}
+        </div>
+
+        {/* Hero: price + name inside image */}
+        {isHero && (
+          <div className="absolute bottom-0 inset-x-0 p-4 z-10">
+            <p className="text-white font-bold text-base sm:text-lg leading-snug line-clamp-2 drop-shadow">
+              {product.name}
+            </p>
+            <div className="flex items-center gap-2 mt-1.5">
+              <span className="text-white font-black text-sm sm:text-base drop-shadow">
+                ৳{Number(price).toLocaleString()}
+              </span>
+              {hasDiscount && (
+                <span className="text-white/60 text-xs line-through">
+                  ৳{Number(product.base_price).toLocaleString()}
+                </span>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* Desktop hover quick-add */}
+        <div className="absolute inset-x-0 bottom-0 translate-y-full group-hover:translate-y-0 transition-transform duration-300 p-3 hidden sm:block z-20">
+          <button
+            onClick={(e) => { e.preventDefault(); onAddToCart(product); }}
+            disabled={!inStock || loadingProductId === product.id}
+            className="w-full flex items-center justify-center gap-2 py-2.5 rounded-xl bg-white/95 dark:bg-gray-900/95 backdrop-blur-sm text-gray-900 dark:text-white text-xs font-bold shadow-lg disabled:opacity-50 disabled:cursor-not-allowed hover:bg-white dark:hover:bg-gray-900 transition-colors"
+          >
+            {loadingProductId === product.id
+              ? <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              : <ShoppingBag className="h-3.5 w-3.5" />
+            }
+            {inStock ? "Quick Add" : "Out of Stock"}
+          </button>
+        </div>
+      </Link>
+
+      {/* ── Info (standard cards only — hero shows inside image) ── */}
+      {!isHero && (
+        <div className="flex items-start justify-between gap-2 p-3">
+          <div className="flex-1 min-w-0">
+            <Link href={`/${store_slug}/product/${product.id}`}>
+              <p className="text-sm font-semibold text-gray-800 dark:text-gray-100 line-clamp-2 leading-snug hover:text-gray-600 dark:hover:text-gray-300 transition-colors">
+                {product.name}
+              </p>
+            </Link>
+            <div className="flex items-baseline gap-1.5 mt-1.5">
+              <span className="text-sm font-black text-gray-900 dark:text-white">
+                ৳{Number(price).toLocaleString()}
+              </span>
+              {hasDiscount && (
+                <span className="text-[11px] text-gray-400 dark:text-gray-500 line-through">
+                  ৳{Number(product.base_price).toLocaleString()}
+                </span>
+              )}
+            </div>
+          </div>
+
+          {/* Mobile add */}
+          <button
+            onClick={() => onAddToCart(product)}
+            disabled={!inStock || loadingProductId === product.id}
+            aria-label={`Add ${product.name} to cart`}
+            className="sm:hidden shrink-0 flex items-center justify-center w-8 h-8 rounded-xl bg-gray-900 dark:bg-white text-white dark:text-gray-900 disabled:opacity-40 disabled:cursor-not-allowed active:scale-90 transition-all"
+          >
+            {loadingProductId === product.id
+              ? <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              : <ShoppingBag className="h-3.5 w-3.5" />
+            }
+          </button>
+        </div>
+      )}
+
+      {/* Hero mobile add button — floats over image */}
+      {isHero && (
+        <button
+          onClick={() => onAddToCart(product)}
+          disabled={!inStock || loadingProductId === product.id}
+          aria-label={`Add ${product.name} to cart`}
+          className="sm:hidden absolute bottom-4 right-4 z-20 flex items-center justify-center w-9 h-9 rounded-xl bg-white text-gray-900 shadow-lg disabled:opacity-40 disabled:cursor-not-allowed active:scale-90 transition-all"
+        >
+          {loadingProductId === product.id
+            ? <Loader2 className="h-4 w-4 animate-spin" />
+            : <ShoppingBag className="h-4 w-4" />
+          }
+        </button>
+      )}
+    </motion.article>
   );
 }

--- a/src/app/[store_slug]/product/[slug]/page.tsx
+++ b/src/app/[store_slug]/product/[slug]/page.tsx
@@ -452,7 +452,7 @@ export default function ProductPage() {
           Product not found.
         </p>
         <a
-          href={`/${store_slug}`}
+          href={`/${store_slug}/shop`}
           className="text-xs font-semibold text-gray-900 dark:text-gray-100 underline underline-offset-4"
         >
           Back to shop
@@ -470,7 +470,7 @@ export default function ProductPage() {
       <div className="sticky top-0 z-40 bg-white/95 dark:bg-gray-900/95 backdrop-blur-sm border-b border-gray-100 dark:border-gray-800 transition-colors duration-200">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 h-14 flex items-center justify-between gap-4">
           <a
-            href={`/${store_slug}`}
+            href={`/${store_slug}/shop`}
             className="flex items-center gap-1.5 text-[13px] font-semibold text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 transition-colors shrink-0"
           >
             <ChevronLeft className="w-4 h-4" />

--- a/src/app/[store_slug]/shop/page.tsx
+++ b/src/app/[store_slug]/shop/page.tsx
@@ -1,0 +1,332 @@
+"use client";
+
+import React, { useEffect, useState, useCallback, useRef } from "react";
+import { useSearchParams } from "next/navigation";
+import { useSheiNotification } from "@/lib/hook/useSheiNotification";
+import useCartStore from "@/lib/store/cartStore";
+import ProductGrid from "../../components/products/ProductGrid";
+import ProductFilterSection from "@/app/components/products/ProductFilterSection";
+import { StorePageSkeleton } from "../../components/skeletons/StorePageSkeleton";
+import { getStoreIdBySlug } from "@/lib/queries/stores/getStoreIdBySlug";
+import { getCategoriesQuery } from "@/lib/queries/categories/getCategories";
+import { clientGetProducts } from "@/lib/queries/products/clientGetProducts";
+import { Product } from "@/lib/types/product";
+import { Category } from "@/lib/types/category";
+import NotFoundPage from "../../not-found";
+import { AddToCartType } from "@/lib/schema/checkoutSchema";
+import { Loader2 } from "lucide-react";
+import { motion } from "framer-motion";
+
+interface ShopPageProps {
+  params: Promise<{ store_slug: string }>;
+}
+
+export default function ShopPage({ params }: ShopPageProps) {
+  const { success, error: showError } = useSheiNotification();
+  const { addToCart } = useCartStore();
+  const { store_slug } = React.use(params);
+  const searchParams = useSearchParams();
+
+  const [storeExists, setStoreExists] = useState<boolean | null>(null);
+  const [products, setProducts] = useState<Product[]>([]);
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [loadingProductId, setLoadingProductId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+
+  const [activeCategory, setActiveCategory] = useState<string>(
+    searchParams.get("category") || "All Products",
+  );
+  const [searchQuery, setSearchQuery] = useState<string>(
+    searchParams.get("search") || "",
+  );
+
+  const [currentPage, setCurrentPage] = useState(1);
+  const [hasMore, setHasMore] = useState(true);
+  const [totalProducts, setTotalProducts] = useState(0);
+
+  const ITEMS_PER_PAGE = 10;
+  const isLoadingRef = useRef(false);
+  const storeIdRef = useRef<string | null>(null);
+  const initializedRef = useRef(false);
+
+  const updateURLParams = (category: string, search: string) => {
+    const p = new URLSearchParams();
+    if (category !== "All Products") p.set("category", category);
+    if (search.trim()) p.set("search", search.trim());
+    const qs = p.toString();
+    window.history.replaceState(
+      {},
+      "",
+      `/${store_slug}/shop${qs ? `?${qs}` : ""}`,
+    );
+  };
+
+  const loadProducts = useCallback(
+    async (
+      page: number,
+      category: string,
+      search: string,
+      isInitialLoad: boolean = false,
+    ) => {
+      if (isLoadingRef.current) return;
+      isLoadingRef.current = true;
+      try {
+        if (isInitialLoad) setLoading(true);
+        else setLoadingMore(true);
+
+        const categoryFilter =
+          category === "All Products" ? undefined : category;
+        const searchFilter = search.trim() || undefined;
+
+        const result = await clientGetProducts(
+          store_slug,
+          page,
+          ITEMS_PER_PAGE,
+          categoryFilter,
+          searchFilter,
+        );
+
+        if (isInitialLoad) setProducts(result.products);
+        else setProducts((prev) => [...prev, ...result.products]);
+
+        setHasMore(result.hasMore);
+        setTotalProducts(result.totalCount);
+      } catch (err) {
+        console.error(err);
+        showError("Failed to load products");
+      } finally {
+        if (isInitialLoad) setLoading(false);
+        else setLoadingMore(false);
+        isLoadingRef.current = false;
+      }
+    },
+    [store_slug, showError],
+  );
+
+  useEffect(() => {
+    if (initializedRef.current) return;
+    initializedRef.current = true;
+
+    async function init() {
+      try {
+        const storeId = await getStoreIdBySlug(store_slug);
+        if (!storeId) {
+          setStoreExists(false);
+          return;
+        }
+
+        storeIdRef.current = storeId;
+        setStoreExists(true);
+
+        const [categoriesData] = await Promise.all([
+          getCategoriesQuery(storeId),
+          loadProducts(1, activeCategory, searchQuery, true),
+        ]);
+
+        if (categoriesData.data) setCategories(categoriesData.data);
+      } catch (err) {
+        console.error(err);
+        showError("Failed to load store data");
+      }
+    }
+
+    init();
+    updateURLParams(activeCategory, searchQuery);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [store_slug]);
+
+  const isFirstFilterRun = useRef(true);
+  useEffect(() => {
+    if (isFirstFilterRun.current) {
+      isFirstFilterRun.current = false;
+      return;
+    }
+    if (!storeIdRef.current) return;
+
+    setCurrentPage(1);
+    setHasMore(true);
+    loadProducts(1, activeCategory, searchQuery, true);
+    updateURLParams(activeCategory, searchQuery);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeCategory, searchQuery]);
+
+  const handleCategoryChange = useCallback((category: string) => {
+    setActiveCategory(category);
+    setSearchQuery("");
+  }, []);
+
+  const handleSearchChange = useCallback((query: string) => {
+    setSearchQuery(query);
+    setActiveCategory("All Products");
+  }, []);
+
+  const handleLoadMore = useCallback(async () => {
+    if (!hasMore || loadingMore || isLoadingRef.current) return;
+    const nextPage = currentPage + 1;
+    setCurrentPage(nextPage);
+    await loadProducts(nextPage, activeCategory, searchQuery, false);
+  }, [
+    hasMore,
+    loadingMore,
+    currentPage,
+    activeCategory,
+    searchQuery,
+    loadProducts,
+  ]);
+
+  const isProductInStock = useCallback((product: Product): boolean => {
+    if (product.variants && product.variants.length > 0) {
+      return product.variants.some((variant) => {
+        const productInventory = variant.product_inventory?.[0];
+        if (productInventory && productInventory.quantity_available > 0)
+          return true;
+        const stock = variant.stock;
+        if (stock && stock.quantity_available > 0) return true;
+        return false;
+      });
+    }
+    const mainProductInventory = product.product_inventory?.[0];
+    if (mainProductInventory && mainProductInventory.quantity_available > 0)
+      return true;
+    const mainStock = product.stock;
+    if (mainStock && mainStock.quantity_available > 0) return true;
+    return false;
+  }, []);
+
+  const handleAddToCart = async (product: Product) => {
+    if (!isProductInStock(product)) {
+      showError("This product is out of stock");
+      return;
+    }
+    setLoadingProductId(product.id);
+    try {
+      const variant = product.variants?.[0];
+      const cartProduct: AddToCartType = {
+        productId: product.id,
+        storeSlug: store_slug,
+        quantity: 1,
+        variantId: variant?.id || null,
+      };
+      addToCart(cartProduct);
+      success(`${product.name} added to cart`);
+    } catch (err) {
+      console.error(err);
+      showError("Failed to add product to cart");
+    } finally {
+      setLoadingProductId(null);
+    }
+  };
+
+  if (loading && products.length === 0) return <StorePageSkeleton />;
+  if (storeExists === false) return <NotFoundPage />;
+
+  return (
+    <div className="min-h-screen bg-white dark:bg-gray-950">
+      <div className="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+        {/* Filter Section */}
+        <ProductFilterSection
+          activeCategory={activeCategory}
+          onCategoryChange={handleCategoryChange}
+          categories={categories}
+          totalProducts={totalProducts}
+          searchQuery={searchQuery}
+          onSearchChange={handleSearchChange}
+        />
+
+        {/* Loading state */}
+        {loading && products.length === 0 ? (
+          <div className="flex justify-center items-center py-32">
+            <Loader2 className="h-7 w-7 animate-spin text-gray-400 dark:text-gray-500" />
+          </div>
+        ) : products.length === 0 ? (
+          <motion.div
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="flex flex-col items-center justify-center py-32 text-center"
+          >
+            <div className="w-16 h-16 rounded-2xl bg-gray-100 dark:bg-gray-800 flex items-center justify-center mb-4 text-2xl">
+              {searchQuery ? "🔍" : "🛍️"}
+            </div>
+            <p className="text-gray-700 dark:text-gray-200 font-semibold text-base">
+              {searchQuery
+                ? `No results for "${searchQuery}"`
+                : activeCategory === "All Products"
+                  ? "No products available yet"
+                  : `Nothing in "${activeCategory}" yet`}
+            </p>
+            <p className="text-gray-400 dark:text-gray-500 text-sm mt-1">
+              Try a different search or category
+            </p>
+          </motion.div>
+        ) : (
+          <>
+            <ProductGrid
+              store_slug={store_slug}
+              products={products}
+              onAddToCart={handleAddToCart}
+              loadingProductId={loadingProductId}
+              productIndexOffset={(currentPage - 1) * ITEMS_PER_PAGE}
+            />
+
+            {/* Load More */}
+            {hasMore && (
+              <motion.div
+                initial={{ opacity: 0, y: 12 }}
+                animate={{ opacity: 1, y: 0 }}
+                className="flex flex-col items-center gap-3 mt-10 mb-16"
+              >
+                <button
+                  onClick={handleLoadMore}
+                  disabled={loadingMore}
+                  className="
+                    group flex items-center gap-2.5 h-12 px-10 rounded-2xl
+                    border-2 border-gray-200 dark:border-gray-700
+                    bg-white dark:bg-gray-900
+                    text-gray-700 dark:text-gray-200
+                    font-semibold text-sm
+                    hover:border-gray-900 dark:hover:border-gray-400
+                    hover:text-gray-900 dark:hover:text-white
+                    hover:bg-gray-50 dark:hover:bg-gray-800
+                    active:scale-[0.98] disabled:opacity-50 disabled:cursor-not-allowed
+                    transition-all duration-200 shadow-sm
+                  "
+                >
+                  {loadingMore ? (
+                    <>
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                      Loading more…
+                    </>
+                  ) : (
+                    <>
+                      Show 10 more products
+                      <span className="text-gray-400 dark:text-gray-500 font-normal text-xs group-hover:text-gray-600 dark:group-hover:text-gray-400 transition-colors">
+                        ({totalProducts - products.length} remaining)
+                      </span>
+                    </>
+                  )}
+                </button>
+              </motion.div>
+            )}
+
+            {/* End state */}
+            {!hasMore && products.length > 0 && (
+              <motion.div
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                className="flex flex-col items-center gap-1 py-12 border-t border-gray-100 dark:border-gray-800"
+              >
+                <p className="text-sm font-semibold text-gray-500 dark:text-gray-400">
+                  All {totalProducts.toLocaleString()} products shown
+                </p>
+                <p className="text-xs text-gray-400 dark:text-gray-500">
+                  You&apos;ve reached the end
+                </p>
+              </motion.div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/components/admin/dashboard/products/MainProduct/ProductTable.tsx
+++ b/src/app/components/admin/dashboard/products/MainProduct/ProductTable.tsx
@@ -5,9 +5,10 @@ import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import DataTable from "@/app/components/admin/common/DataTable";
 import type { ColumnsType } from "antd/es/table";
 import { ProductWithVariants } from "@/lib/queries/products/getProductsWithVariants";
-import { Edit, Trash2 } from "lucide-react";
+import { Edit, Trash2, Star } from "lucide-react";
 import { Modal } from "antd";
 import { deleteProduct } from "@/lib/queries/products/deleteProduct";
+import { toggleProductFeatured } from "@/lib/queries/products/toggleProductFeatured";
 import { useSheiNotification } from "@/lib/hook/useSheiNotification";
 import Image from "next/image";
 import ProductCardLayout from "@/app/components/admin/common/ProductCardLayout";
@@ -138,10 +139,31 @@ const ProductTable: React.FC<ProductTableProps> = ({
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [modalOpen, setModalOpen] = useState(false);
   const [deleteLoading, setDeleteLoading] = useState(false);
+  const [featuredOverrides, setFeaturedOverrides] = useState<
+    Record<string, boolean>
+  >({});
+  const [togglingId, setTogglingId] = useState<string | null>(null);
   const sheiNotif = useSheiNotification();
   const { icon: currencyIcon, loading: currencyLoading } =
     useUserCurrencyIcon();
   const cur = currencyLoading ? "" : (currencyIcon ?? "৳");
+
+  const getFeatured = (record: ProductWithVariants) =>
+    featuredOverrides[record.id] ?? record.featured;
+
+  const handleToggleFeatured = async (record: ProductWithVariants) => {
+    const next = !getFeatured(record);
+    setFeaturedOverrides((prev) => ({ ...prev, [record.id]: next }));
+    setTogglingId(record.id);
+    try {
+      await toggleProductFeatured(record.id, next);
+    } catch {
+      setFeaturedOverrides((prev) => ({ ...prev, [record.id]: !next }));
+      sheiNotif.error("Failed to update featured status");
+    } finally {
+      setTogglingId(null);
+    }
+  };
 
   const handleEdit = (slug: string) => {
     const params = new URLSearchParams(searchParams.toString());
@@ -266,6 +288,40 @@ const ProductTable: React.FC<ProductTableProps> = ({
       },
     },
     {
+      title: "Featured",
+      key: "featured",
+      align: "center",
+      width: 88,
+      responsive: ["md"],
+      render: (_, record) => {
+        const isFeatured = getFeatured(record);
+        const isToggling = togglingId === record.id;
+        return (
+          <div className="flex justify-center">
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                handleToggleFeatured(record);
+              }}
+              disabled={isToggling}
+              title={isFeatured ? "Remove from featured" : "Mark as featured"}
+              className={`flex items-center justify-center w-8 h-8 rounded-lg border transition-all duration-150 disabled:opacity-50 disabled:cursor-not-allowed
+                ${
+                  isFeatured
+                    ? "bg-amber-50 dark:bg-amber-500/15 border-amber-300 dark:border-amber-500 text-amber-500 hover:bg-amber-100 dark:hover:bg-amber-500/25"
+                    : "bg-white dark:bg-slate-800 border-gray-200 dark:border-slate-700 text-gray-300 dark:text-slate-600 hover:bg-amber-50 dark:hover:bg-amber-500/10 hover:border-amber-300 hover:text-amber-400"
+                }`}
+            >
+              <Star
+                className="w-3.5 h-3.5"
+                fill={isFeatured ? "currentColor" : "none"}
+              />
+            </button>
+          </div>
+        );
+      },
+    },
+    {
       title: "Status",
       key: "status",
       align: "center",
@@ -384,6 +440,22 @@ const ProductTable: React.FC<ProductTableProps> = ({
                       className="flex gap-1.5 ml-auto"
                       onClick={(e) => e.stopPropagation()}
                     >
+                      <button
+                        onClick={() => handleToggleFeatured(record)}
+                        disabled={togglingId === record.id}
+                        title={getFeatured(record) ? "Remove from featured" : "Mark as featured"}
+                        className={`flex items-center justify-center w-8 h-8 rounded-lg border transition-all duration-150 disabled:opacity-50
+                          ${
+                            getFeatured(record)
+                              ? "bg-amber-50 dark:bg-amber-500/15 border-amber-300 dark:border-amber-500 text-amber-500"
+                              : "bg-white dark:bg-slate-800 border-gray-200 dark:border-slate-700 text-gray-300 dark:text-slate-600"
+                          }`}
+                      >
+                        <Star
+                          className="w-3.5 h-3.5"
+                          fill={getFeatured(record) ? "currentColor" : "none"}
+                        />
+                      </button>
                       <EditButton onClick={() => handleEdit(record.slug)} />
                       <DeleteButton
                         onClick={() => showDeleteModal(record.id)}

--- a/src/app/components/admin/dashboard/products/MainProduct/Products.tsx
+++ b/src/app/components/admin/dashboard/products/MainProduct/Products.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState, useCallback } from "react";
 import { Button, Input, Space, Pagination } from "antd";
 import { useRouter } from "next/navigation";
 import { SearchOutlined, PlusOutlined } from "@ant-design/icons";
+import { Star } from "lucide-react";
 import ProductTable from "./ProductTable";
 import {
   getProductsWithVariants,
@@ -37,6 +38,11 @@ const Products: React.FC = () => {
     "ALL",
     (v) => v as ProductStatus | "ALL",
   );
+  const [featuredOnly, setFeaturedOnly] = useUrlSync<boolean>(
+    "featured",
+    false,
+    (v) => v === "true",
+  );
 
   const [localSearch, setLocalSearch] = useState(search);
   const [products, setProducts] = useState<ProductWithVariants[]>([]);
@@ -48,6 +54,7 @@ const Products: React.FC = () => {
     [ProductStatus.DRAFT]: 0,
     ALL: 0,
   });
+  const [featuredCount, setFeaturedCount] = useState(0);
 
   const fetchProducts = useCallback(async () => {
     if (!user?.store_id) return;
@@ -59,16 +66,18 @@ const Products: React.FC = () => {
         page,
         pageSize,
         status: status === "ALL" ? undefined : status,
+        featured: featuredOnly ? true : undefined,
       });
       setProducts(res.data);
       setTotal(res.total);
       setCounts(res.counts);
+      setFeaturedCount(res.featuredCount);
     } catch (error) {
       console.error("Failed to fetch products:", error);
     } finally {
       setLoading(false);
     }
-  }, [user?.store_id, search, page, pageSize, status]);
+  }, [user?.store_id, search, page, pageSize, status, featuredOnly]);
 
   useEffect(() => {
     fetchProducts();
@@ -140,12 +149,13 @@ const Products: React.FC = () => {
         {/* Status pills — desktop */}
         <div className="hidden md:flex items-center gap-1.5 flex-wrap">
           {statusConfig.map(({ key, label }) => {
-            const isActive = status === key;
+            const isActive = status === key && !featuredOnly;
             return (
               <button
                 key={key}
                 onClick={() => {
                   setStatus(key as ProductStatus | "ALL");
+                  setFeaturedOnly(false);
                   setPage(1);
                 }}
                 className={`inline-flex items-center gap-1.5 px-3.5 py-1.5 rounded-full text-xs font-semibold border transition-all duration-150 cursor-pointer
@@ -169,6 +179,36 @@ const Products: React.FC = () => {
               </button>
             );
           })}
+
+          {/* Featured pill */}
+          <button
+            onClick={() => {
+              setFeaturedOnly(!featuredOnly);
+              setPage(1);
+            }}
+            className={`inline-flex items-center gap-1.5 px-3.5 py-1.5 rounded-full text-xs font-semibold border transition-all duration-150 cursor-pointer
+              ${
+                featuredOnly
+                  ? "bg-amber-400 border-amber-400 text-white shadow-md shadow-amber-400/25"
+                  : "bg-white dark:bg-slate-800 border-gray-200 dark:border-slate-700 text-gray-600 dark:text-slate-300 hover:border-amber-400 hover:text-amber-500 dark:hover:text-amber-400 hover:bg-amber-50 dark:hover:bg-amber-500/10"
+              }`}
+          >
+            <Star
+              className="w-3 h-3"
+              fill={featuredOnly ? "currentColor" : "none"}
+            />
+            Featured
+            <span
+              className={`inline-flex items-center justify-center min-w-5 h-4.5 px-1.5 rounded-full text-[10px] font-bold
+              ${
+                featuredOnly
+                  ? "bg-white/20 text-white"
+                  : "bg-gray-100 dark:bg-slate-700 text-gray-500 dark:text-slate-400"
+              }`}
+            >
+              {featuredCount}
+            </span>
+          </button>
         </div>
 
         {/* Status — mobile dropdown */}
@@ -184,6 +224,7 @@ const Products: React.FC = () => {
             ]}
             onChange={(v) => {
               setStatus(v);
+              setFeaturedOnly(false);
               setPage(1);
             }}
             getLabel={(s) =>

--- a/src/app/components/admin/dashboard/products/addProducts/AddProductForm.tsx
+++ b/src/app/components/admin/dashboard/products/addProducts/AddProductForm.tsx
@@ -659,7 +659,27 @@ const AddProductForm = forwardRef<AddProductFormRef, AddProductFormProps>(
 
           {/* ── Status + Submit ── */}
           <div className="flex flex-col items-start justify-between gap-4 rounded-2xl border border-border bg-card p-6 sm:flex-row sm:items-center">
-            <div className="flex items-center gap-3">
+            <div className="flex flex-wrap items-center gap-4">
+              {/* Featured toggle */}
+              <label className="flex items-center gap-2 cursor-pointer select-none">
+                <input
+                  type="checkbox"
+                  {...form.register("featured")}
+                  className="sr-only peer"
+                  id="featured"
+                />
+                <div className="relative w-9 h-5 rounded-full bg-muted border border-border peer-checked:bg-amber-400 peer-checked:border-amber-400 transition-colors duration-200 after:content-[''] after:absolute after:top-0.5 after:left-0.5 after:w-4 after:h-4 after:rounded-full after:bg-white after:shadow after:transition-transform after:duration-200 peer-checked:after:translate-x-4" />
+                <span className="text-sm font-medium flex items-center gap-1.5">
+                  Featured
+                  <Tooltip title="Featured products appear highlighted in your store homepage." placement="top">
+                    <Info className="h-3.5 w-3.5 cursor-help text-muted-foreground hover:text-foreground transition-colors" />
+                  </Tooltip>
+                </span>
+              </label>
+
+              <div className="w-px h-5 bg-border hidden sm:block" />
+
+              <div className="flex items-center gap-3">
               <label htmlFor="status" className="text-sm font-medium">
                 Status
               </label>
@@ -694,6 +714,7 @@ const AddProductForm = forwardRef<AddProductFormRef, AddProductFormProps>(
                   <Info className="h-4 w-4 cursor-help text-muted-foreground hover:text-foreground transition-colors" />
                 </Tooltip>
               )}
+              </div>
             </div>
 
             <Button

--- a/src/app/components/common/DesktopHeaderforStore.tsx
+++ b/src/app/components/common/DesktopHeaderforStore.tsx
@@ -59,7 +59,8 @@ export default function DesktopHeader({
   }, [storeSlug]);
 
   const navLinks: NavLink[] = [
-    { name: "Shop", path: `/${storeSlug}` },
+    { name: "Home", path: `/${storeSlug}` },
+    { name: "Shop", path: `/${storeSlug}/shop` },
     { name: "Generate Order", path: `/${storeSlug}/generate-orders-link` },
   ];
 

--- a/src/app/components/common/MobileHeaderforStore.tsx
+++ b/src/app/components/common/MobileHeaderforStore.tsx
@@ -87,7 +87,8 @@ export default function MobileHeader({
   }, [pathname]);
 
   const navLinks: NavLink[] = [
-    { name: "Shop", path: `/${storeSlug}` },
+    { name: "Home", path: `/${storeSlug}` },
+    { name: "Shop", path: `/${storeSlug}/shop` },
     { name: "Generate Order", path: `/${storeSlug}/generate-orders-link` },
   ];
 

--- a/src/app/components/products/shop/ProductCard.tsx
+++ b/src/app/components/products/shop/ProductCard.tsx
@@ -146,7 +146,7 @@ export default function ProductCard({
     >
       {/* ── Image (square, never shrinks) ── */}
       <Link
-        href={`${store_slug}/product/${product.slug}`}
+        href={`/${store_slug}/product/${product.slug}`}
         className="block relative overflow-hidden bg-gray-50 dark:bg-gray-800 shrink-0"
         style={{ aspectRatio: "1/1" }}
       >
@@ -166,6 +166,11 @@ export default function ProductCard({
           </span>
 
           <div className="flex flex-col items-end gap-1">
+            {product.featured && productInStock && (
+              <span className="text-[9px] font-bold uppercase tracking-wider bg-amber-400 text-amber-950 px-2 py-1 rounded-full shadow-sm whitespace-nowrap">
+                Featured
+              </span>
+            )}
             {!productInStock && (
               <span className="text-[9px] font-bold uppercase tracking-wider bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 px-2 py-1 rounded-full whitespace-nowrap">
                 Sold Out
@@ -196,7 +201,7 @@ export default function ProductCard({
       <div className="flex flex-col p-3 sm:p-4 gap-2 flex-1">
         {/* Row 1 — Name: fixed 2-line height, hard clamp, no overflow */}
         <Link
-          href={`${store_slug}/product/${product.slug}`}
+          href={`/${store_slug}/product/${product.slug}`}
           className="block h-10 sm:h-11 overflow-hidden"
         >
           <h3
@@ -252,7 +257,7 @@ export default function ProductCard({
         <div className="flex gap-1.5 mt-auto">
           {hasVariants ? (
             <Link
-              href={`${store_slug}/product/${product.slug}`}
+              href={`/${store_slug}/product/${product.slug}`}
               className="flex-1"
             >
               <button className="w-full flex items-center justify-center gap-1.5 h-9 rounded-xl bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 text-xs font-semibold tracking-wide hover:bg-gray-700 dark:hover:bg-gray-300 active:scale-[0.98] transition-all duration-200">
@@ -300,7 +305,7 @@ export default function ProductCard({
                 </button>
               )}
               <Link
-                href={`${store_slug}/product/${product.slug}`}
+                href={`/${store_slug}/product/${product.slug}`}
                 className={productInStock && !isMaxInCart ? "" : "flex-1"}
               >
                 <button

--- a/src/app/components/skeletons/StoreHomePageSkeleton.tsx
+++ b/src/app/components/skeletons/StoreHomePageSkeleton.tsx
@@ -1,0 +1,99 @@
+// Skeleton that mirrors the store home page layout:
+// banner → identity bar → category tabs → bento grid (1 hero + 4 standard)
+import React from "react";
+
+function Shimmer() {
+  return (
+    <div
+      className="absolute inset-0 -translate-x-full animate-[shimmer_1.6s_infinite]"
+      style={{
+        background:
+          "linear-gradient(90deg,transparent 0%,rgba(255,255,255,0.15) 40%,rgba(255,255,255,0.28) 50%,rgba(255,255,255,0.15) 60%,transparent 100%)",
+      }}
+    />
+  );
+}
+
+function Bone({ className, style }: { className: string; style?: React.CSSProperties }) {
+  return (
+    <div style={style} className={`relative overflow-hidden rounded-lg bg-gray-100 dark:bg-gray-800 ${className}`}>
+      <Shimmer />
+    </div>
+  );
+}
+
+export function StoreHomePageSkeleton() {
+  return (
+    <div className="min-h-screen bg-white dark:bg-gray-950 animate-pulse">
+
+      {/* ── Banner ── */}
+      <div className="relative w-full h-64 sm:h-80 lg:h-110 bg-gray-100 dark:bg-gray-800 overflow-hidden">
+        <Shimmer />
+
+        {/* Identity bar at banner bottom */}
+        <div className="absolute bottom-0 inset-x-0">
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pb-5 flex items-end justify-between gap-4">
+            <div className="flex items-center gap-3">
+              <Bone className="w-13 h-13 rounded-xl shrink-0" />
+              <div className="flex flex-col gap-2">
+                <Bone className="h-5 w-36 rounded-md" />
+                <Bone className="h-3 w-52 rounded-md" />
+              </div>
+            </div>
+            <Bone className="h-10 w-28 rounded-full shrink-0" />
+          </div>
+        </div>
+      </div>
+
+      {/* ── Category tabs ── */}
+      <div className="border-b border-gray-100 dark:border-gray-800">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex items-center gap-1 py-1 overflow-hidden">
+            {[40, 64, 56, 72, 48, 60].map((w, i) => (
+              <Bone key={i} className="h-10 rounded-none mx-2" style={{ width: w }} />
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* ── Section label ── */}
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-10 pb-6 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Bone className="w-4 h-4 rounded-sm" />
+          <Bone className="h-4 w-28 rounded-md" />
+          <Bone className="h-3 w-12 rounded-md" />
+        </div>
+        <Bone className="h-3 w-14 rounded-md" />
+      </div>
+
+      {/* ── Bento grid ── */}
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pb-24">
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 sm:gap-4">
+
+          {/* Hero card */}
+          <div className="sm:col-span-2 sm:row-span-2 rounded-2xl overflow-hidden bg-gray-100 dark:bg-gray-800 relative aspect-3/4 sm:min-h-120">
+            <Shimmer />
+            {/* Fake name + price at bottom */}
+            <div className="absolute bottom-0 inset-x-0 p-4 flex flex-col gap-2">
+              <Bone className="h-4 w-3/4 rounded-md" />
+              <Bone className="h-4 w-1/3 rounded-md" />
+            </div>
+          </div>
+
+          {/* 4 standard cards */}
+          {[0, 1, 2, 3].map((i) => (
+            <div key={i} className="rounded-2xl overflow-hidden bg-gray-100 dark:bg-gray-800 flex flex-col">
+              <div className="relative aspect-square overflow-hidden">
+                <Shimmer />
+              </div>
+              <div className="p-3 flex flex-col gap-2 bg-white dark:bg-gray-900">
+                <Bone className="h-3.5 w-4/5 rounded-md" />
+                <Bone className="h-3.5 w-2/5 rounded-md" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/components/skeletons/StoreHomePageSkeleton.tsx
+++ b/src/app/components/skeletons/StoreHomePageSkeleton.tsx
@@ -1,5 +1,5 @@
 // Skeleton that mirrors the store home page layout:
-// banner → identity bar → category tabs → bento grid (1 hero + 4 standard)
+// banner → identity bar → category card grid → featured bento grid
 import React from "react";
 
 function Shimmer() {
@@ -24,20 +24,20 @@ function Bone({ className, style }: { className: string; style?: React.CSSProper
 
 export function StoreHomePageSkeleton() {
   return (
-    <div className="min-h-screen bg-white dark:bg-gray-950 animate-pulse">
+    <div className="min-h-screen bg-[#F8F8F6] dark:bg-gray-950 animate-pulse">
 
       {/* ── Banner ── */}
-      <div className="relative w-full h-64 sm:h-80 lg:h-110 bg-gray-100 dark:bg-gray-800 overflow-hidden">
+      <div className="relative w-full h-72 sm:h-96 lg:h-120 bg-gray-200 dark:bg-gray-800 overflow-hidden">
         <Shimmer />
 
-        {/* Identity bar at banner bottom */}
+        {/* Identity overlay at banner bottom */}
         <div className="absolute bottom-0 inset-x-0">
-          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pb-5 flex items-end justify-between gap-4">
-            <div className="flex items-center gap-3">
-              <Bone className="w-13 h-13 rounded-xl shrink-0" />
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pb-7 flex items-end justify-between gap-4">
+            <div className="flex items-center gap-3.5">
+              <Bone className="w-14 h-14 rounded-2xl shrink-0" />
               <div className="flex flex-col gap-2">
                 <Bone className="h-5 w-36 rounded-md" />
-                <Bone className="h-3 w-52 rounded-md" />
+                <Bone className="h-3 w-48 rounded-md" />
               </div>
             </div>
             <Bone className="h-10 w-28 rounded-full shrink-0" />
@@ -45,49 +45,73 @@ export function StoreHomePageSkeleton() {
         </div>
       </div>
 
-      {/* ── Category tabs ── */}
-      <div className="border-b border-gray-100 dark:border-gray-800">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex items-center gap-1 py-1 overflow-hidden">
-            {[40, 64, 56, 72, 48, 60].map((w, i) => (
-              <Bone key={i} className="h-10 rounded-none mx-2" style={{ width: w }} />
+      {/* ── Shop by Category section ── */}
+      <div className="bg-white dark:bg-gray-950 border-b border-gray-100 dark:border-gray-800">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12 sm:py-16">
+
+          {/* Section header */}
+          <div className="flex items-end justify-between mb-8 sm:mb-10">
+            <div className="flex flex-col gap-2">
+              <Bone className="h-2.5 w-24 rounded-full" />
+              <Bone className="h-7 w-48 rounded-lg" />
+            </div>
+            <Bone className="h-4 w-16 rounded-md hidden sm:block" />
+          </div>
+
+          {/* Category card grid — 2 cols mobile, 3 sm, 6 lg */}
+          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3 sm:gap-4">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div
+                key={i}
+                className="rounded-2xl bg-white dark:bg-gray-900 border border-gray-100 dark:border-gray-800 overflow-hidden"
+              >
+                <div className="h-0.5 bg-gray-100 dark:bg-gray-800" />
+                <div className="flex flex-col items-center gap-3 px-3 py-6 sm:py-7">
+                  <Bone className="w-11 h-11 rounded-xl" />
+                  <Bone className="h-3.5 w-3/4 rounded-md" />
+                  <Bone className="h-2.5 w-1/2 rounded-md" />
+                </div>
+              </div>
             ))}
           </div>
         </div>
       </div>
 
-      {/* ── Section label ── */}
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-10 pb-6 flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <Bone className="w-4 h-4 rounded-sm" />
-          <Bone className="h-4 w-28 rounded-md" />
-          <Bone className="h-3 w-12 rounded-md" />
-        </div>
-        <Bone className="h-3 w-14 rounded-md" />
-      </div>
+      {/* ── Featured Products section ── */}
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-12 pb-24 sm:pt-16">
 
-      {/* ── Bento grid ── */}
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pb-24">
+        {/* Section header */}
+        <div className="flex items-end justify-between mb-7 sm:mb-9">
+          <div className="flex flex-col gap-2">
+            <Bone className="h-2.5 w-20 rounded-full" />
+            <div className="flex items-center gap-2.5">
+              <Bone className="h-7 w-40 rounded-lg" />
+              <Bone className="h-6 w-10 rounded-full hidden sm:block" />
+            </div>
+          </div>
+          <Bone className="h-4 w-14 rounded-md" />
+        </div>
+
+        {/* Bento grid — hero + 4 standard */}
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 sm:gap-4">
 
           {/* Hero card */}
-          <div className="sm:col-span-2 sm:row-span-2 rounded-2xl overflow-hidden bg-gray-100 dark:bg-gray-800 relative aspect-3/4 sm:min-h-120">
+          <div className="sm:col-span-2 sm:row-span-2 rounded-2xl overflow-hidden bg-gray-200 dark:bg-gray-800 relative aspect-3/4 sm:min-h-120">
             <Shimmer />
-            {/* Fake name + price at bottom */}
-            <div className="absolute bottom-0 inset-x-0 p-4 flex flex-col gap-2">
+            <div className="absolute bottom-0 inset-x-0 p-4 sm:p-5 flex flex-col gap-2">
               <Bone className="h-4 w-3/4 rounded-md" />
               <Bone className="h-4 w-1/3 rounded-md" />
             </div>
           </div>
 
           {/* 4 standard cards */}
-          {[0, 1, 2, 3].map((i) => (
-            <div key={i} className="rounded-2xl overflow-hidden bg-gray-100 dark:bg-gray-800 flex flex-col">
-              <div className="relative aspect-square overflow-hidden">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="rounded-2xl overflow-hidden bg-white dark:bg-gray-900 border border-gray-100 dark:border-gray-800 flex flex-col shadow-[0_2px_12px_rgba(0,0,0,0.05)]">
+              <div className="relative aspect-square bg-gray-100 dark:bg-gray-800 overflow-hidden">
                 <Shimmer />
               </div>
-              <div className="p-3 flex flex-col gap-2 bg-white dark:bg-gray-900">
-                <Bone className="h-3.5 w-4/5 rounded-md" />
+              <div className="px-3.5 py-3 flex flex-col gap-2">
+                <Bone className="h-3.5 w-5/6 rounded-md" />
                 <Bone className="h-3.5 w-2/5 rounded-md" />
               </div>
             </div>

--- a/src/lib/queries/products/clientGetProducts.ts
+++ b/src/lib/queries/products/clientGetProducts.ts
@@ -40,6 +40,7 @@ export async function clientGetProducts(
         short_description,
         base_price,
         discounted_price,
+        featured,
         status,
         categories(id, name, slug),
         product_variants(
@@ -117,6 +118,7 @@ export async function clientGetProducts(
         discounted_price: p.discounted_price
           ? Number(p.discounted_price)
           : null,
+        featured: p.featured ?? false,
         status: (p.status as ProductStatus) || ProductStatus.ACTIVE,
         category: p.categories
           ? { 

--- a/src/lib/queries/products/getFeaturedProducts.ts
+++ b/src/lib/queries/products/getFeaturedProducts.ts
@@ -1,0 +1,104 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { supabase } from "@/lib/supabase";
+import { Product } from "@/lib/types/product";
+import { ProductStatus } from "@/lib/types/enums";
+
+export async function getFeaturedProducts(
+  store_slug: string,
+  limit: number = 8
+): Promise<Product[]> {
+  const { data: storeData, error: storeError } = await supabase
+    .from("stores")
+    .select("id")
+    .eq("store_slug", store_slug)
+    .single();
+
+  if (storeError || !storeData) return [];
+
+  const { data: products, error } = await supabase
+    .from("products")
+    .select(
+      `
+      id,
+      name,
+      slug,
+      description,
+      base_price,
+      discounted_price,
+      status,
+      featured,
+      categories(id, name, slug),
+      product_variants(
+        id,
+        variant_name,
+        base_price,
+        discounted_price,
+        color,
+        is_active,
+        product_inventory(quantity_available, quantity_reserved),
+        product_images(id, image_url, is_primary)
+      ),
+      product_images(id, image_url, is_primary),
+      product_inventory(quantity_available, quantity_reserved),
+      created_at
+    `
+    )
+    .eq("store_id", storeData.id)
+    .eq("status", ProductStatus.ACTIVE)
+    .eq("featured", true)
+    .order("created_at", { ascending: false })
+    .limit(limit);
+
+  if (error || !products) return [];
+
+  return products.map((p: any) => {
+    const primary_image =
+      p.product_images?.find((img: any) => img.is_primary) ||
+      p.product_images?.[0] ||
+      null;
+    const baseStock = p.product_inventory?.[0] || {
+      quantity_available: 0,
+      quantity_reserved: 0,
+    };
+
+    return {
+      id: p.id,
+      name: p.name,
+      slug: p.slug,
+      description: p.description,
+      base_price: Number(p.base_price),
+      discounted_price: p.discounted_price ? Number(p.discounted_price) : null,
+      status: (p.status as ProductStatus) || ProductStatus.ACTIVE,
+      featured: p.featured === true,
+      category: p.categories
+        ? { id: p.categories.id, name: p.categories.name, slug: p.categories.slug }
+        : null,
+      images: p.product_images?.map((img: any) => img.image_url) || [],
+      primary_image,
+      product_inventory: baseStock,
+      stock: baseStock.quantity_available > 0 ? baseStock : null,
+      variants: (p.product_variants ?? [])
+        .filter((v: any) => v.is_active)
+        .map((v: any) => ({
+          id: v.id,
+          product_id: p.id,
+          variant_name: v.variant_name,
+          base_price: Number(v.base_price),
+          discounted_price: v.discounted_price ? Number(v.discounted_price) : null,
+          color: v.color,
+          is_active: v.is_active ?? true,
+          stock: v.product_inventory?.[0] || {
+            quantity_available: 0,
+            quantity_reserved: 0,
+          },
+          product_inventory: v.product_inventory?.[0],
+          primary_image:
+            v.product_images?.find((img: any) => img.is_primary) ||
+            v.product_images?.[0] ||
+            null,
+          product_images: v.product_images ?? [],
+        })),
+      created_at: p.created_at,
+    } as Product;
+  });
+}

--- a/src/lib/queries/products/getProductsWithVariants.ts
+++ b/src/lib/queries/products/getProductsWithVariants.ts
@@ -49,6 +49,7 @@ export interface ProductWithVariants {
   sku: string | null;
   base_price: number | null;
   discounted_price: number | null;
+  featured: boolean;
   category_id: string | null;
   category?: Category | null;
   product_images: ProductImage[];
@@ -67,16 +68,19 @@ export async function getProductsWithVariants({
   page,
   pageSize,
   status,
+  featured,
 }: {
   storeId: string;
   search?: string;
   page?: number;
   pageSize?: number;
   status?: ProductStatus;
+  featured?: boolean;
 }): Promise<{
   data: ProductWithVariants[];
   total: number;
   counts: Record<ProductStatus | "ALL", number>;
+  featuredCount: number;
 }> {
   // ------------------ 1️⃣ Fetch products ------------------
   const query = supabase
@@ -89,6 +93,7 @@ export async function getProductsWithVariants({
       sku,
       base_price,
       status,
+      featured,
       discounted_price,
       category_id,
       categories (id, name),
@@ -136,6 +141,7 @@ export async function getProductsWithVariants({
 
   if (search?.trim()) query.ilike("name", `%${search.trim()}%`);
   if (status) query.eq("status", status);
+  if (featured !== undefined) query.eq("featured", featured);
 
   if (page !== undefined && pageSize !== undefined) {
     const from = (page - 1) * pageSize;
@@ -153,6 +159,7 @@ export async function getProductsWithVariants({
     sku: p.sku,
     base_price: p.base_price,
     status: p.status ?? ProductStatus.INACTIVE,
+    featured: p.featured ?? false,
     discounted_price: p.discounted_price,
     category_id: p.category_id,
     category: p.categories
@@ -176,10 +183,10 @@ export async function getProductsWithVariants({
     product_inventory: p.product_inventory ?? [],
   })) as ProductWithVariants[];
 
-  // ------------------ 2️⃣ Fetch counts per status ------------------
+  // ------------------ 2️⃣ Fetch counts per status + featured ------------------
   const { data: countData, error: countError } = await supabase
     .from("products")
-    .select("status", { count: "exact" })
+    .select("status, featured")
     .eq("store_id", storeId);
 
   if (countError) throw countError;
@@ -191,15 +198,19 @@ export async function getProductsWithVariants({
     ALL: 0,
   };
 
+  let featuredCount = 0;
+
   countData?.forEach((p: any) => {
     const s = p.status as ProductStatus;
     if (s in counts) counts[s] += 1;
     counts.ALL += 1;
+    if (p.featured) featuredCount += 1;
   });
 
   return {
     data: products,
     total: count ?? 0,
     counts,
+    featuredCount,
   };
 }

--- a/src/lib/queries/products/toggleProductFeatured.ts
+++ b/src/lib/queries/products/toggleProductFeatured.ts
@@ -1,0 +1,13 @@
+import { supabaseAdmin } from "@/lib/supabase";
+
+export async function toggleProductFeatured(
+  productId: string,
+  featured: boolean,
+): Promise<void> {
+  const { error } = await supabaseAdmin
+    .from("products")
+    .update({ featured })
+    .eq("id", productId);
+
+  if (error) throw error;
+}

--- a/src/lib/queries/stores/getStoreBySlugFull.ts
+++ b/src/lib/queries/stores/getStoreBySlugFull.ts
@@ -5,6 +5,7 @@ export interface StoreFull {
   store_name: string;
   store_slug: string;
   logo_url: string | null;
+  banner_url: string | null;
   description: string | null;
   created_at: string;
   contact_email: string | null;
@@ -33,6 +34,7 @@ export async function getStoreBySlugFull(store_slug: string): Promise<StoreFull 
       store_name,
       store_slug,
       logo_url,
+      banner_url,
       description,
       contact_email,
       contact_phone,

--- a/src/lib/types/product.ts
+++ b/src/lib/types/product.ts
@@ -43,11 +43,12 @@ export interface Product {
   name: string;
   slug: string;
   base_price: number;
-  discounted_price?: number;
+  discounted_price?: number | null;
+  featured?: boolean;
   category?: Category | null;
   primary_image?: ProductImage | null;
   images?: string[];
   stock?: ProductStock | null;
-  product_inventory?: ProductInventory[]; // Added this
+  product_inventory?: ProductInventory[];
   variants?: ProductVariant[];
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,18 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
@@ -18,9 +22,10 @@
         "name": "next"
       }
     ],
-    "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     }
   },
   "include": [
@@ -29,5 +34,7 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
### **Store Homepage — Featured Bento Layout & Shop Page**
**Summary**
Rebuilt the store homepage (/[store_slug]) from a generic product-listing page into a proper branded landing experience — hero/identity banner, category tab strip, and a featured-products bento grid
New /shop page (/[store_slug]/shop) — full paginated, filterable product catalogue moved here so the homepage stays curated and fast
Featured products query (getFeaturedProducts) fetches up to 5 store-admin-curated products using the featured flag, with a bento layout (1 large hero card + up to 4 standard cards)
StoreHomePageSkeleton added for proper loading state on the new homepage
Headers updated (DesktopHeaderforStore, MobileHeaderforStore) to reflect the new store routing

**### What Changed**

| Area | Type | Description |
|------|------|-------------|
| [store_slug]/page.tsx | Refactor (Full Rewrite) | Rebuilt homepage with identity-driven banner, category navigation tabs, and a featured product bento grid for stronger visual hierarchy |
| [store_slug]/shop/page.tsx | New Feature | Introduced dedicated shop page with full product catalogue, including search, filtering, and pagination capabilities |
| getFeaturedProducts.ts | New | Added query utility to fetch featured=true products per store for dynamic homepage rendering |
| StoreHomePageSkeleton.tsx | New | Implemented skeleton loader to improve perceived performance during homepage data fetch |
| getStoreBySlugFull.ts | Enhancement | Extended response to include logo_url and description for richer store identity display |
| Headers | Update | Added navigation link to Shop page to streamline user journey |


**### Featured Product — Toggle, Filter & Table Badge**
**Summary**

- Mark products as Featured from both Add Product and Edit Product forms via an inline toggle switch in the footer bar
- One-click toggle in the product table — star icon per row; golden when featured, gray when not; uses optimistic updates so the UI flips instantly without a full reload
- Featured filter pill in the products toolbar — click to filter the table to only featured products; shows a live count badge


### What Changed

| File | Type | Description |
|------|------|-------------|
| toggleProductFeatured.ts | New | Lightweight query to update only the `featured` column for a product |
| getProductsWithVariants.ts | Enhancement | Added optional `featured?: boolean` filter param and `featuredCount` in response |
| AddProductForm.tsx | Update | Introduced featured toggle switch in Status/Submit footer (supports both Add & Edit flows) |
| ProductTable.tsx | Update | Added featured column with centered star toggle, optimistic UI update, and mobile card compatibility |
| Products.tsx | Update | Implemented featured filter pill (URL-synced), added `featuredCount` state, and integrated with product fetch logic |